### PR TITLE
fix(simulator/GraphhopperManager): securityGroup config passed properly to ecs.runTask

### DIFF
--- a/packages/@prototype/simulator/src/SimulatorManagerStack/DestinationSimulatorLambda/DestinationStarterStepFunction/index.ts
+++ b/packages/@prototype/simulator/src/SimulatorManagerStack/DestinationSimulatorLambda/DestinationStarterStepFunction/index.ts
@@ -56,7 +56,7 @@ export class DestinationStarterStepFunction extends Construct {
 			CLUSTER_NAME: cluster.clusterName,
 			TASK_DEFINITION_NAME: destinationSimulatorContainer.taskDefinition.taskDefinitionArn,
 			SUBNETS: vpc.publicSubnets.map(q => q.subnetId).join(','),
-			SECURITY_GROUP: securityGroup.securityGroupId, // TODO: CDKv2 make sure Id is ok to use instead of securityGroupName,
+			SECURITY_GROUP: securityGroup.securityGroupId,
 			CONTAINER_NAME: destinationSimulatorContainer.containerDefinition.containerName,
 		}
 		this.lambda = new lambda.Function(this, 'DestinationStarterHelper', {

--- a/packages/@prototype/simulator/src/SimulatorManagerStack/GraphhopperManager/@lambda/src/index.js
+++ b/packages/@prototype/simulator/src/SimulatorManagerStack/GraphhopperManager/@lambda/src/index.js
@@ -32,7 +32,7 @@ const handler = (event, context) => {
 			config.taskDefinitionName,
 			config.containerName,
 			config.subnets,
-			[config.securityGroups],
+			[config.securityGroup],
 		)
 		const { failures, tasks } = res
 

--- a/packages/@prototype/simulator/src/SimulatorManagerStack/GraphhopperManager/index.ts
+++ b/packages/@prototype/simulator/src/SimulatorManagerStack/GraphhopperManager/index.ts
@@ -47,7 +47,7 @@ export class GraphhopperManager extends Construct {
 				CLUSTER_NAME: props.cluster.clusterName,
 				TASK_DEFINITION_NAME: props.taskDefinition.taskDefinitionArn,
 				SUBNETS: props.vpc.publicSubnets.map(q => q.subnetId).join(','),
-				SECURITY_GROUP: props.securityGroup.securityGroupId, // TODO CDKv2 make sure that this parameter will be used properly .securityGroupName,
+				SECURITY_GROUP: props.securityGroup.securityGroupId,
 				CONTAINER_NAME: props.containerDefinition.containerName,
 			},
 			initialPolicy: [

--- a/packages/@prototype/simulator/src/SimulatorManagerStack/OriginSimulatorLambda/OriginStarterStepFunction/index.ts
+++ b/packages/@prototype/simulator/src/SimulatorManagerStack/OriginSimulatorLambda/OriginStarterStepFunction/index.ts
@@ -62,7 +62,7 @@ export class OriginStarterStepFunction extends Construct {
 				CLUSTER_NAME: cluster.clusterName,
 				TASK_DEFINITION_NAME: originSimulatorContainer.taskDefinition.taskDefinitionArn,
 				SUBNETS: vpc.publicSubnets.map(q => q.subnetId).join(','),
-				SECURITY_GROUP: securityGroup.securityGroupId, // TODO: CDKv2 make sure Id is ok to use // .securityGroupName,
+				SECURITY_GROUP: securityGroup.securityGroupId,
 				CONTAINER_NAME: originSimulatorContainer.containerDefinition.containerName,
 			},
 			initialPolicy: [

--- a/packages/@prototype/simulator/src/SimulatorManagerStack/SimulatorManagerLambda/ECSStepFunctionInvoker/index.ts
+++ b/packages/@prototype/simulator/src/SimulatorManagerStack/SimulatorManagerLambda/ECSStepFunctionInvoker/index.ts
@@ -50,7 +50,7 @@ export class ECSStepFunctionInvoker extends Construct {
 				CLUSTER_NAME: props.cluster.clusterName,
 				TASK_DEFINITION_NAME: props.taskDefinition.taskDefinitionArn,
 				SUBNETS: props.vpc.publicSubnets.map(q => q.subnetId).join(','),
-				SECURITY_GROUP: props.securityGroup.securityGroupId, // TODO CDKv2 make sure Id is ok to use .securityGroupName,
+				SECURITY_GROUP: props.securityGroup.securityGroupId,
 				CONTAINER_NAME: props.containerDefinition.containerName,
 				SIMULATOR_TABLE_NAME: props.simulatorTable.tableName,
 			},


### PR DESCRIPTION
*Issue #, if available:* #29

*Description of changes:*
* securityGroup config passed properly to ecs.runTask in GraphhopperManager lambda
* removed comments to investigate `securityGroupId` after CDK upgrade

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
