### PR TITLE
feat(memorydb): swap RedisCluster to MemoryDBCluster

### DIFF
--- a/packages/@prototype/api-geotracking/src/ApiGeofencing/GeofencingService/index.ts
+++ b/packages/@prototype/api-geotracking/src/ApiGeofencing/GeofencingService/index.ts
@@ -15,7 +15,7 @@
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
 import { Construct } from 'constructs'
-import { Duration, aws_lambda as lambda, aws_iam as iam, aws_events as events, aws_ec2 as ec2, aws_elasticache as elasticache } from 'aws-cdk-lib'
+import { Duration, aws_lambda as lambda, aws_iam as iam, aws_events as events, aws_ec2 as ec2, aws_memorydb as memorydb } from 'aws-cdk-lib'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
 import { namespaced } from '@aws-play/cdk-core'
 import { LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
@@ -23,14 +23,14 @@ import { SERVICE_NAME } from '@prototype/common'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface Environment extends DeclaredLambdaEnvironment {
-    readonly REDIS_HOST: string
-    readonly REDIS_PORT: string
+    readonly MEMORYDB_HOST: string
+    readonly MEMORYDB_PORT: string
 }
 
 interface Dependencies extends DeclaredLambdaDependencies {
 	readonly vpc: ec2.IVpc
 	readonly lambdaSecurityGroups: ec2.ISecurityGroup[]
-	readonly redisCluster: elasticache.CfnCacheCluster
+	readonly memoryDBCluster: memorydb.CfnCluster
 	readonly lambdaLayers: lambda.ILayerVersion[]
 	readonly eventBus: events.EventBus
 }
@@ -42,7 +42,7 @@ export class GeofencingServiceLambda extends DeclaredLambdaFunction<Environment,
 		const {
 			vpc,
 			lambdaSecurityGroups,
-			redisCluster,
+			memoryDBCluster,
 			lambdaLayers,
 			eventBus,
 		} = props.dependencies
@@ -54,8 +54,8 @@ export class GeofencingServiceLambda extends DeclaredLambdaFunction<Environment,
 			dependencies: props.dependencies,
 			timeout: Duration.seconds(120),
 			environment: {
-				REDIS_HOST: redisCluster.attrRedisEndpointAddress,
-				REDIS_PORT: redisCluster.attrRedisEndpointPort,
+				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
+				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
 				EVENT_BUS_NAME: eventBus.eventBusName,
 				SERVICE_NAME: SERVICE_NAME.GEOFENCING_SERVICE,
 			},

--- a/packages/@prototype/api-geotracking/src/ApiGeofencing/index.ts
+++ b/packages/@prototype/api-geotracking/src/ApiGeofencing/index.ts
@@ -15,7 +15,7 @@
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
 import { Construct } from 'constructs'
-import { aws_apigateway as apigw, aws_cognito as cognito, aws_events as events, aws_ec2 as ec2, aws_elasticache as elasticache, aws_lambda as lambda } from 'aws-cdk-lib'
+import { aws_apigateway as apigw, aws_cognito as cognito, aws_events as events, aws_ec2 as ec2, aws_memorydb as memorydb, aws_lambda as lambda } from 'aws-cdk-lib'
 import { RestApi } from '@aws-play/cdk-apigateway'
 import { namespaced } from '@aws-play/cdk-core'
 import HTTPMethod from 'http-method-enum'
@@ -30,7 +30,7 @@ export interface ApiGeofencingProps {
 	readonly lambdaLayers: { [key: string]: lambda.ILayerVersion, }
 	readonly vpc: ec2.IVpc
 	readonly lambdaSecurityGroups: ec2.ISecurityGroup[]
-	readonly redisCluster: elasticache.CfnCacheCluster
+	readonly memoryDBCluster: memorydb.CfnCluster
 }
 
 export class ApiGeofencing extends Construct {
@@ -45,7 +45,7 @@ export class ApiGeofencing extends Construct {
 			userPool,
 			eventBus,
 			vpc,
-			redisCluster,
+			memoryDBCluster,
 			lambdaLayers,
 			lambdaSecurityGroups,
 		} = props
@@ -60,7 +60,7 @@ export class ApiGeofencing extends Construct {
 				eventBus,
 				vpc,
 				lambdaSecurityGroups,
-				redisCluster,
+				memoryDBCluster,
 				lambdaLayers: [
 					lambdaLayers.lambdaUtilsLayer,
 					lambdaLayers.redisClientLayer,

--- a/packages/@prototype/api-geotracking/src/ApiGeotracking/GetDemAreaSettings/index.ts
+++ b/packages/@prototype/api-geotracking/src/ApiGeotracking/GetDemAreaSettings/index.ts
@@ -15,7 +15,7 @@
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
 import { Construct } from 'constructs'
-import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_elasticache as elasticache, aws_dynamodb as ddb } from 'aws-cdk-lib'
+import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_memorydb as memorydb, aws_dynamodb as ddb } from 'aws-cdk-lib'
 import { namespaced } from '@aws-play/cdk-core'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
 import { LambdaInsightsExecutionPolicy, readDDBTablePolicyStatement } from '@prototype/lambda-common'

--- a/packages/@prototype/api-geotracking/src/ApiGeotracking/GetDriverLocation/index.ts
+++ b/packages/@prototype/api-geotracking/src/ApiGeotracking/GetDriverLocation/index.ts
@@ -15,21 +15,21 @@
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
 import { Construct } from 'constructs'
-import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_elasticache as elasticache } from 'aws-cdk-lib'
+import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_memorydb as memorydb } from 'aws-cdk-lib'
 import { namespaced } from '@aws-play/cdk-core'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
 import { LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface Environment extends DeclaredLambdaEnvironment {
-    readonly REDIS_HOST: string
-    readonly REDIS_PORT: string
+    readonly MEMORYDB_HOST: string
+    readonly MEMORYDB_PORT: string
 }
 
 interface Dependencies extends DeclaredLambdaDependencies {
 	readonly vpc: ec2.IVpc
 	readonly lambdaSecurityGroups: ec2.ISecurityGroup[]
-	readonly redisCluster: elasticache.CfnCacheCluster
+	readonly memoryDBCluster: memorydb.CfnCluster
     readonly lambdaLayers: lambda.ILayerVersion[]
 }
 
@@ -40,7 +40,7 @@ export class GetDriverLocationLambda extends DeclaredLambdaFunction<Environment,
 		const {
 			vpc,
 			lambdaSecurityGroups,
-			redisCluster,
+			memoryDBCluster,
 			lambdaLayers,
 		} = props.dependencies
 
@@ -51,8 +51,8 @@ export class GetDriverLocationLambda extends DeclaredLambdaFunction<Environment,
 			dependencies: props.dependencies,
 			timeout: Duration.seconds(30),
 			environment: {
-				REDIS_HOST: redisCluster.attrRedisEndpointAddress,
-				REDIS_PORT: redisCluster.attrRedisEndpointPort,
+				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
+				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
 
 			},
 			layers: lambdaLayers,

--- a/packages/@prototype/api-geotracking/src/ApiGeotracking/ListDriversForPolygon/index.ts
+++ b/packages/@prototype/api-geotracking/src/ApiGeotracking/ListDriversForPolygon/index.ts
@@ -15,15 +15,15 @@
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
 import { Construct } from 'constructs'
-import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_dynamodb as ddb, aws_elasticache as elasticache, aws_opensearchservice as opensearchservice } from 'aws-cdk-lib'
+import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_dynamodb as ddb, aws_memorydb as memorydb, aws_opensearchservice as opensearchservice } from 'aws-cdk-lib'
 import { namespaced } from '@aws-play/cdk-core'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
 import { AllowOpenSearchRead, AllowOpenSearchWrite, readDDBTablePolicyStatement, LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface Environment extends DeclaredLambdaEnvironment {
-	readonly REDIS_HOST: string
-	readonly REDIS_PORT: string
+	readonly MEMORYDB_HOST: string
+	readonly MEMORYDB_PORT: string
 	readonly POLYGON_TABLE: string
 	readonly DOMAIN_ENDPOINT: string
 }
@@ -31,7 +31,7 @@ interface Environment extends DeclaredLambdaEnvironment {
 interface Dependencies extends DeclaredLambdaDependencies {
 	readonly vpc: ec2.IVpc
 	readonly lambdaSecurityGroups: ec2.ISecurityGroup[]
-	readonly redisCluster: elasticache.CfnCacheCluster
+	readonly memoryDBCluster: memorydb.CfnCluster
 	readonly lambdaLayers: lambda.ILayerVersion[]
 	readonly geoPolygonTable: ddb.ITable
 	readonly openSearchDomain: opensearchservice.IDomain
@@ -44,7 +44,7 @@ export class ListDriversForPolygonLambda extends DeclaredLambdaFunction<Environm
 		const {
 			vpc,
 			lambdaSecurityGroups,
-			redisCluster,
+			memoryDBCluster,
 			lambdaLayers,
 			geoPolygonTable,
 			openSearchDomain,
@@ -57,8 +57,8 @@ export class ListDriversForPolygonLambda extends DeclaredLambdaFunction<Environm
 			dependencies: props.dependencies,
 			timeout: Duration.seconds(30),
 			environment: {
-				REDIS_HOST: redisCluster.attrRedisEndpointAddress,
-				REDIS_PORT: redisCluster.attrRedisEndpointPort,
+				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
+				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
 				POLYGON_TABLE: geoPolygonTable.tableName,
 				DOMAIN_ENDPOINT: openSearchDomain.domainEndpoint,
 

--- a/packages/@prototype/api-geotracking/src/ApiGeotracking/QueryDrivers/index.ts
+++ b/packages/@prototype/api-geotracking/src/ApiGeotracking/QueryDrivers/index.ts
@@ -15,21 +15,21 @@
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
 import { Construct } from 'constructs'
-import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_elasticache as elasticache } from 'aws-cdk-lib'
+import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_memorydb as memorydb } from 'aws-cdk-lib'
 import { namespaced } from '@aws-play/cdk-core'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
 import { LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface Environment extends DeclaredLambdaEnvironment {
-	readonly REDIS_HOST: string
-	readonly REDIS_PORT: string
+	readonly MEMORYDB_HOST: string
+	readonly MEMORYDB_PORT: string
 }
 
 interface Dependencies extends DeclaredLambdaDependencies {
 	readonly vpc: ec2.IVpc
 	readonly lambdaSecurityGroups: ec2.ISecurityGroup[]
-	readonly redisCluster: elasticache.CfnCacheCluster
+	readonly memoryDBCluster: memorydb.CfnCluster
 	readonly lambdaLayers: lambda.ILayerVersion[]
 }
 
@@ -40,7 +40,7 @@ export class QueryDriversLambda extends DeclaredLambdaFunction<Environment, Depe
 		const {
 			vpc,
 			lambdaSecurityGroups,
-			redisCluster,
+			memoryDBCluster,
 			lambdaLayers,
 		} = props.dependencies
 
@@ -51,8 +51,8 @@ export class QueryDriversLambda extends DeclaredLambdaFunction<Environment, Depe
 			dependencies: props.dependencies,
 			timeout: Duration.seconds(30),
 			environment: {
-				REDIS_HOST: redisCluster.attrRedisEndpointAddress,
-				REDIS_PORT: redisCluster.attrRedisEndpointPort,
+				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
+				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
 
 			},
 			layers: lambdaLayers,

--- a/packages/@prototype/api-geotracking/src/ApiGeotracking/index.ts
+++ b/packages/@prototype/api-geotracking/src/ApiGeotracking/index.ts
@@ -15,7 +15,7 @@
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
 import { Construct } from 'constructs'
-import { aws_apigateway as apigw, aws_cognito as cognito, aws_lambda as lambda, aws_ec2 as ec2, aws_elasticache as elasticache, aws_dynamodb as ddb, aws_opensearchservice as opensearchservice } from 'aws-cdk-lib'
+import { aws_apigateway as apigw, aws_cognito as cognito, aws_lambda as lambda, aws_ec2 as ec2, aws_memorydb as memorydb, aws_dynamodb as ddb, aws_opensearchservice as opensearchservice } from 'aws-cdk-lib'
 import { RestApi } from '@aws-play/cdk-apigateway'
 import { namespaced } from '@aws-play/cdk-core'
 import HTTPMethod from 'http-method-enum'
@@ -32,7 +32,7 @@ export interface ApiGeoTrackingProps {
 	readonly lambdaLayers: { [key: string]: lambda.ILayerVersion, }
 	readonly vpc: ec2.IVpc
 	readonly lambdaSecurityGroups: ec2.ISecurityGroup[]
-	readonly redisCluster: elasticache.CfnCacheCluster
+	readonly memoryDBCluster: memorydb.CfnCluster
 	readonly geoPolygonTable: ddb.ITable
 	readonly demographicAreaDispatchSettings: ddb.ITable
 	readonly openSearchDomain: opensearchservice.IDomain
@@ -53,7 +53,7 @@ export class ApiGeoTracking extends Construct {
 			apiPrefix = 'api/geotracking',
 			lambdaLayers,
 			userPool,
-			vpc, lambdaSecurityGroups, redisCluster,
+			vpc, lambdaSecurityGroups, memoryDBCluster,
 			geoPolygonTable,
 			demographicAreaDispatchSettings,
 			openSearchDomain,
@@ -85,7 +85,7 @@ export class ApiGeoTracking extends Construct {
 			dependencies: {
 				vpc,
 				lambdaSecurityGroups,
-				redisCluster,
+				memoryDBCluster,
 				lambdaLayers: [
 					lambdaLayers.lambdaUtilsLayer,
 					lambdaLayers.redisClientLayer,
@@ -116,7 +116,7 @@ export class ApiGeoTracking extends Construct {
 			dependencies: {
 				vpc,
 				lambdaSecurityGroups,
-				redisCluster,
+				memoryDBCluster,
 				lambdaLayers: [
 					lambdaLayers.lambdaUtilsLayer,
 					lambdaLayers.redisClientLayer,
@@ -175,7 +175,7 @@ export class ApiGeoTracking extends Construct {
 			dependencies: {
 				vpc,
 				lambdaSecurityGroups,
-				redisCluster,
+				memoryDBCluster,
 				lambdaLayers: [
 					lambdaLayers.lambdaUtilsLayer,
 					lambdaLayers.redisClientLayer,

--- a/packages/@prototype/lambda-common/README.md
+++ b/packages/@prototype/lambda-common/README.md
@@ -35,7 +35,7 @@ const apiGeotracking = new ApiGeoTracking(this, 'ApiGeoTracking', {
     lambdaLayers, // <----------
     vpc,
     lambdaSecurityGroups: [securityGroups.lambda],
-    redisCluster,
+    memoryDBCluster,
     geoPolygonTable,
     openSearchDomain: elasticSearchCluster,
 })

--- a/packages/@prototype/lambda-common/src/RedisClientLayer/@lambda/index.js
+++ b/packages/@prototype/lambda-common/src/RedisClientLayer/@lambda/index.js
@@ -19,7 +19,7 @@ const redis = require('redis')
 let client = null
 exports.getRedisClient = () => {
 	if (client == null) {
-		client = redis.createClient(process.env.REDIS_PORT, process.env.REDIS_HOST, { no_ready_check: true })
+		client = redis.createClient(process.env.MEMORYDB_PORT, process.env.MEMORYDB_HOST, { no_ready_check: true })
 	}
 
 	return client

--- a/packages/@prototype/lambda-functions/README.md
+++ b/packages/@prototype/lambda-functions/README.md
@@ -42,11 +42,11 @@ import { LambdaFunctions } from '@prototype/lambda-functions';
 const lambdaFunctions = new LambdaFunctions(this, 'LambdaFunctions', {
     vpc,
     lambdaSecurityGroups: [securityGroups.lambda],
-    redisCluster,
+    memoryDBCluster,
     lambdaLayers,
     cleanupScheduleMins: 1,
     driverDataIngestStream: driverDataStream.driverDataIngestStream,
-    driverLocationUpdateTTLInMs: redisConfig.driverLocationUpdateTTLInMS as number,
+    driverLocationUpdateTTLInMs: memoryDBConfig.driverLocationUpdateTTLInMS as number,
     openSearchDomain: elasticSearchCluster,
     eventBus,
     geofencingBatchSize: kinesisConfig.geofencingBatchSize as number,

--- a/packages/@prototype/lambda-functions/src/LambdaFunctions/DriverGeofencingLambda/index.ts
+++ b/packages/@prototype/lambda-functions/src/LambdaFunctions/DriverGeofencingLambda/index.ts
@@ -15,7 +15,7 @@
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
 import { Construct } from 'constructs'
-import { Duration, aws_kinesis as kinesis, aws_ec2 as ec2, aws_lambda as lambda, aws_events as events, aws_iam as iam, aws_elasticache as elasticache, aws_opensearchservice as opensearchservice } from 'aws-cdk-lib'
+import { Duration, aws_kinesis as kinesis, aws_ec2 as ec2, aws_lambda as lambda, aws_events as events, aws_iam as iam, aws_memorydb as memorydb, aws_opensearchservice as opensearchservice } from 'aws-cdk-lib'
 import { namespaced } from '@aws-play/cdk-core'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
 import { Kinesis } from 'cdk-iam-actions/lib/actions'
@@ -26,7 +26,7 @@ import { SERVICE_NAME } from '@prototype/common'
 export interface DriverGeofencingtLambdaExternalDeps {
 	readonly vpc: ec2.IVpc
 	readonly lambdaSecurityGroups: ec2.ISecurityGroup[]
-	readonly redisCluster: elasticache.CfnCacheCluster
+	readonly memoryDBCluster: memorydb.CfnCluster
 	readonly lambdaLayers: lambda.ILayerVersion[]
 	readonly openSearchDomain: opensearchservice.IDomain
 	readonly eventBus: events.EventBus
@@ -34,8 +34,8 @@ export interface DriverGeofencingtLambdaExternalDeps {
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface Environment extends DeclaredLambdaEnvironment {
-	readonly REDIS_HOST: string
-	readonly REDIS_PORT: string
+	readonly MEMORYDB_HOST: string
+	readonly MEMORYDB_PORT: string
 }
 
 interface Dependencies extends DeclaredLambdaDependencies {
@@ -52,7 +52,7 @@ export class DriverGeofencingtLambda extends DeclaredLambdaFunction<Environment,
 			externalDeps: {
 				vpc,
 				lambdaSecurityGroups,
-				redisCluster,
+				memoryDBCluster,
 				lambdaLayers,
 				eventBus,
 			},
@@ -65,8 +65,8 @@ export class DriverGeofencingtLambda extends DeclaredLambdaFunction<Environment,
 			dependencies: props.dependencies,
 			timeout: Duration.seconds(30),
 			environment: {
-				REDIS_HOST: redisCluster.attrRedisEndpointAddress,
-				REDIS_PORT: redisCluster.attrRedisEndpointPort,
+				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
+				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
 				EVENT_BUS: eventBus.eventBusName,
 				SERVICE_NAME: SERVICE_NAME.GEOFENCING_SERVICE,
 			},

--- a/packages/@prototype/lambda-functions/src/LambdaFunctions/DriverLocationCleanupLambda/index.ts
+++ b/packages/@prototype/lambda-functions/src/LambdaFunctions/DriverLocationCleanupLambda/index.ts
@@ -15,15 +15,15 @@
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
 import { Construct } from 'constructs'
-import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_elasticache as elasticache, aws_opensearchservice as opensearchservice } from 'aws-cdk-lib'
+import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_memorydb as memorydb, aws_opensearchservice as opensearchservice } from 'aws-cdk-lib'
 import { namespaced } from '@aws-play/cdk-core'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
 import { AllowOpenSearchDelete, AllowOpenSearchWrite, LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface Environment extends DeclaredLambdaEnvironment {
-    readonly REDIS_HOST: string
-    readonly REDIS_PORT: string
+    readonly MEMORYDB_HOST: string
+    readonly MEMORYDB_PORT: string
 	readonly DRIVER_LOCATION_UPDATE_TTL_MS: string
 	readonly DOMAIN_ENDPOINT: string
 }
@@ -31,7 +31,7 @@ interface Environment extends DeclaredLambdaEnvironment {
 interface Dependencies extends DeclaredLambdaDependencies {
 	readonly vpc: ec2.IVpc
 	readonly lambdaSecurityGroups: ec2.ISecurityGroup[]
-	readonly redisCluster: elasticache.CfnCacheCluster
+	readonly memoryDBCluster: memorydb.CfnCluster
 	readonly lambdaLayers: lambda.ILayerVersion[]
 	readonly driverLocationUpdateTTLInMs: number
 	readonly openSearchDomain: opensearchservice.IDomain
@@ -44,7 +44,7 @@ export class DriverLocationCleanupLambda extends DeclaredLambdaFunction<Environm
 		const {
 			vpc,
 			lambdaSecurityGroups,
-			redisCluster,
+			memoryDBCluster,
 			lambdaLayers,
 			driverLocationUpdateTTLInMs,
 			openSearchDomain,
@@ -57,8 +57,8 @@ export class DriverLocationCleanupLambda extends DeclaredLambdaFunction<Environm
 			dependencies: props.dependencies,
 			timeout: Duration.seconds(30),
 			environment: {
-				REDIS_HOST: redisCluster.attrRedisEndpointAddress,
-				REDIS_PORT: redisCluster.attrRedisEndpointPort,
+				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
+				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
 				DRIVER_LOCATION_UPDATE_TTL_MS: `${driverLocationUpdateTTLInMs}`,
 				DOMAIN_ENDPOINT: openSearchDomain.domainEndpoint,
 

--- a/packages/@prototype/lambda-functions/src/LambdaFunctions/DriverLocationUpdateIngestLambda/index.ts
+++ b/packages/@prototype/lambda-functions/src/LambdaFunctions/DriverLocationUpdateIngestLambda/index.ts
@@ -15,7 +15,7 @@
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
 import { Construct } from 'constructs'
-import { Duration, aws_kinesis as kinesis, aws_ec2 as ec2, aws_lambda as lambda, aws_iam as iam, aws_elasticache as elasticache, aws_opensearchservice as opensearchservice } from 'aws-cdk-lib'
+import { Duration, aws_kinesis as kinesis, aws_ec2 as ec2, aws_lambda as lambda, aws_iam as iam, aws_memorydb as memorydb, aws_opensearchservice as opensearchservice } from 'aws-cdk-lib'
 import { namespaced } from '@aws-play/cdk-core'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
 import { Kinesis } from 'cdk-iam-actions/lib/actions'
@@ -25,7 +25,7 @@ import { AllowOpenSearchWrite, LambdaInsightsExecutionPolicy } from '@prototype/
 export interface DriverLocationUpdateIngestLambdaExternalDeps {
 	readonly vpc: ec2.IVpc
 	readonly lambdaSecurityGroups: ec2.ISecurityGroup[]
-	readonly redisCluster: elasticache.CfnCacheCluster
+	readonly memoryDBCluster: memorydb.CfnCluster
 	readonly lambdaLayers: lambda.ILayerVersion[]
 	readonly driverLocationUpdateTTLInMs: number
 	readonly openSearchDomain: opensearchservice.IDomain
@@ -34,8 +34,8 @@ export interface DriverLocationUpdateIngestLambdaExternalDeps {
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface Environment extends DeclaredLambdaEnvironment {
 	readonly DRIVER_LOCATION_UPDATE_TTL_MS: string
-	readonly REDIS_HOST: string
-	readonly REDIS_PORT: string
+	readonly MEMORYDB_HOST: string
+	readonly MEMORYDB_PORT: string
 	readonly DOMAIN_ENDPOINT: string
 }
 
@@ -53,7 +53,7 @@ export class DriverLocationUpdateIngestLambda extends DeclaredLambdaFunction<Env
 			externalDeps: {
 				vpc,
 				lambdaSecurityGroups,
-				redisCluster,
+				memoryDBCluster,
 				lambdaLayers,
 				driverLocationUpdateTTLInMs,
 				openSearchDomain,
@@ -67,8 +67,8 @@ export class DriverLocationUpdateIngestLambda extends DeclaredLambdaFunction<Env
 			dependencies: props.dependencies,
 			timeout: Duration.seconds(30),
 			environment: {
-				REDIS_HOST: redisCluster.attrRedisEndpointAddress,
-				REDIS_PORT: redisCluster.attrRedisEndpointPort,
+				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
+				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
 				DRIVER_LOCATION_UPDATE_TTL_MS: `${driverLocationUpdateTTLInMs}`,
 				DOMAIN_ENDPOINT: openSearchDomain.domainEndpoint,
 			},

--- a/packages/@prototype/lambda-functions/src/LambdaFunctions/DriverStatusUpdateIngestLambda/index.ts
+++ b/packages/@prototype/lambda-functions/src/LambdaFunctions/DriverStatusUpdateIngestLambda/index.ts
@@ -15,7 +15,7 @@
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
 import { Construct } from 'constructs'
-import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_events as events, aws_iam as iam, aws_opensearchservice as opensearchservice, aws_elasticache as elasticache } from 'aws-cdk-lib'
+import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_events as events, aws_iam as iam, aws_opensearchservice as opensearchservice, aws_memorydb as memorydb } from 'aws-cdk-lib'
 import { namespaced } from '@aws-play/cdk-core'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
 import { AllowOpenSearchWrite, LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
@@ -24,8 +24,8 @@ import { SERVICE_NAME } from '@prototype/common'
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface Environment extends DeclaredLambdaEnvironment {
 	readonly DOMAIN_ENDPOINT: string
-	readonly REDIS_HOST: string
-	readonly REDIS_PORT: string
+	readonly MEMORYDB_HOST: string
+	readonly MEMORYDB_PORT: string
 	readonly EVENT_BUS_NAME: string
 	readonly SERVICE_NAME: string
 }
@@ -33,7 +33,7 @@ interface Environment extends DeclaredLambdaEnvironment {
 interface Dependencies extends DeclaredLambdaDependencies {
 	readonly vpc: ec2.IVpc
 	readonly lambdaSecurityGroups: ec2.ISecurityGroup[]
-	readonly redisCluster: elasticache.CfnCacheCluster
+	readonly memoryDBCluster: memorydb.CfnCluster
 	readonly lambdaLayers: lambda.ILayerVersion[]
 	readonly eventBus: events.EventBus
 	readonly openSearchDomain: opensearchservice.IDomain
@@ -46,7 +46,7 @@ export class DriverStatusUpdateLambda extends DeclaredLambdaFunction<Environment
 		const {
 			vpc,
 			lambdaSecurityGroups,
-			redisCluster,
+			memoryDBCluster,
 			lambdaLayers,
 			eventBus,
 			openSearchDomain,
@@ -59,8 +59,8 @@ export class DriverStatusUpdateLambda extends DeclaredLambdaFunction<Environment
 			dependencies: props.dependencies,
 			timeout: Duration.seconds(30),
 			environment: {
-				REDIS_HOST: redisCluster.attrRedisEndpointAddress,
-				REDIS_PORT: redisCluster.attrRedisEndpointPort,
+				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
+				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
 				EVENT_BUS_NAME: eventBus.eventBusName,
 				SERVICE_NAME: SERVICE_NAME.DRIVER_SERVICE,
 				DOMAIN_ENDPOINT: openSearchDomain.domainEndpoint,

--- a/packages/@prototype/lambda-functions/src/LambdaFunctions/index.ts
+++ b/packages/@prototype/lambda-functions/src/LambdaFunctions/index.ts
@@ -15,7 +15,7 @@
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
 import { Construct } from 'constructs'
-import { aws_ec2 as ec2, aws_lambda as lambda, aws_elasticache as elasticache, aws_events as events, aws_opensearchservice as opensearchservice, aws_events_targets as events_targets, aws_kinesis as kinesis } from 'aws-cdk-lib'
+import { aws_ec2 as ec2, aws_lambda as lambda, aws_memorydb as memorydb, aws_events as events, aws_opensearchservice as opensearchservice, aws_events_targets as events_targets, aws_kinesis as kinesis } from 'aws-cdk-lib'
 import { KinesisConsumer } from '@prototype/lambda-common'
 import { DriverLocationCleanupLambda } from './DriverLocationCleanupLambda'
 import { namespaced } from '@aws-play/cdk-core'
@@ -28,7 +28,7 @@ import { OpenSearchInitialSetupLambda } from './OpenSearchInitialSetupLambda'
 export interface LambdaFunctionsProps {
 	readonly vpc: ec2.IVpc
 	readonly lambdaSecurityGroups: ec2.ISecurityGroup[]
-	readonly redisCluster: elasticache.CfnCacheCluster
+	readonly memoryDBCluster: memorydb.CfnCluster
 	readonly lambdaLayers: { [key: string]: lambda.ILayerVersion, }
 	readonly cleanupScheduleMins: number
 	readonly driverDataIngestStream: kinesis.IStream
@@ -63,7 +63,7 @@ export class LambdaFunctions extends Construct {
 
 		const {
 			vpc, lambdaSecurityGroups,
-			redisCluster, lambdaLayers,
+			memoryDBCluster, lambdaLayers,
 			cleanupScheduleMins,
 			driverDataIngestStream,
 			driverLocationUpdateTTLInMs,
@@ -85,7 +85,7 @@ export class LambdaFunctions extends Construct {
 			dependencies: {
 				vpc,
 				lambdaSecurityGroups,
-				redisCluster,
+				memoryDBCluster,
 				lambdaLayers: [
 					lambdaLayers.lambdaUtilsLayer,
 					lambdaLayers.redisClientLayer,
@@ -121,7 +121,7 @@ export class LambdaFunctions extends Construct {
 						lambdaLayers.openSearchClientLayer,
 						lambdaLayers.lambdaInsightsLayer,
 					],
-					redisCluster,
+					memoryDBCluster,
 					driverLocationUpdateTTLInMs,
 					openSearchDomain,
 				},
@@ -151,7 +151,7 @@ export class LambdaFunctions extends Construct {
 						lambdaLayers.openSearchClientLayer,
 						lambdaLayers.lambdaInsightsLayer,
 					],
-					redisCluster,
+					memoryDBCluster,
 					openSearchDomain,
 					eventBus,
 				},
@@ -175,7 +175,7 @@ export class LambdaFunctions extends Construct {
 				eventBus,
 				vpc,
 				lambdaSecurityGroups,
-				redisCluster,
+				memoryDBCluster,
 				lambdaLayers: [
 					lambdaLayers.lambdaUtilsLayer,
 					lambdaLayers.redisClientLayer,

--- a/packages/@prototype/live-data-cache/README.md
+++ b/packages/@prototype/live-data-cache/README.md
@@ -2,7 +2,7 @@
 
 Resources holding live/recent data in the system.
 
-* RedisCluster: an Elasticache Redis cluster with a redis subnet group. 
+* memoryDBCluster: an Elasticache Redis cluster with a redis subnet group. 
 * OpenSearchCluster: an Elastic search domain setup in the VPC, spread to all availability zones, with a Kibana access via `InternalIdentityStack` cognito (for operators).
   * ESSetup is a custom resource that generates the initial index with custom mappings as the last phase of the deployment.
 
@@ -23,9 +23,9 @@ const liveDataCluster = new LiveDataCache(this, 'LiveDataCache', {
         lambdaLayers,
         lambdaSecurityGroups: [securityGroups.lambda],
     },
-    redisClusterProps: {
+    memoryDBClusterProps: {
         numNodes: 1,
-        nodeType: redisConfig.instanceType as string,
+        nodeType: memoryDBConfig.instanceType as string,
         securityGroups: [securityGroups.redis],
         vpc,
     },

--- a/packages/@prototype/live-data-cache/src/LiveDataCache/MemoryDBCluster/index.ts
+++ b/packages/@prototype/live-data-cache/src/LiveDataCache/MemoryDBCluster/index.ts
@@ -1,0 +1,81 @@
+/*********************************************************************************************************************
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.                                               *
+ *                                                                                                                   *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy of                                  *
+ *  this software and associated documentation files (the "Software"), to deal in                                    *
+ *  the Software without restriction, including without limitation the rights to                                     *
+ *  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of                                 *
+ *  the Software, and to permit persons to whom the Software is furnished to do so.                                  *
+ *                                                                                                                   *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR                                       *
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS                                 *
+ *  FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR                                   *
+ *  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER                                   *
+ *  IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN                                          *
+ *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
+ *********************************************************************************************************************/
+/* eslint-disable no-console */
+import { Construct } from 'constructs'
+import { aws_memorydb as memorydb, aws_ec2 as ec2 } from 'aws-cdk-lib'
+import { namespaced } from '@aws-play/cdk-core'
+
+export interface MemoryDBClusterProps {
+	readonly numShards?: number
+	readonly numReplicasPerShard?: number
+	readonly nodeType?: string
+	readonly vpc: ec2.IVpc
+	readonly securityGroups: ec2.ISecurityGroup[]
+}
+
+export class MemoryDBCluster extends Construct {
+	readonly cluster: memorydb.CfnCluster
+
+	constructor (scope: Construct, id: string, props: MemoryDBClusterProps) {
+		super(scope, id)
+
+		const {
+			vpc, securityGroups,
+			nodeType, numShards, numReplicasPerShard,
+		} = props
+
+		const commonName = namespaced(this, 'live-data', { lowerCase: true }) // NOTE: lowercase
+
+		const subnetGroup = new memorydb.CfnSubnetGroup(this, 'MemoryDBClusterSubnetGroup', {
+			subnetGroupName: commonName,
+			description: 'Subnet for LiveData MemoryDBCluster',
+			subnetIds: vpc.selectSubnets({ subnetType: ec2.SubnetType.PRIVATE_ISOLATED }).subnetIds,
+		})
+
+		const acl = new memorydb.CfnACL(this, 'MemoryDBACL', {
+			aclName: commonName,
+		})
+
+		// const parameterGroup = new memorydb.CfnParameterGroup(this, 'MemoryDBParameterGroup', {
+		// 	family: 'memorydb_redis6', // magic string
+		// 	parameterGroupName: commonName,
+		// 	description: 'ParameterGroup for LiveData MemoryDBCluster',
+		// 	parameters: { ?? },
+		// })
+
+		const cluster = new memorydb.CfnCluster(this, 'MemoryDBCluster', {
+			aclName: acl.ref,
+			clusterName: commonName,
+			// eslint-disable-next-line max-len
+			// https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html#CacheNodes.SupportedTypesByRegion
+			nodeType: nodeType || 'cache.t3.medium',
+
+			autoMinorVersionUpgrade: true,
+			description: 'MemDB for Hyperlocal',
+			numReplicasPerShard: numReplicasPerShard || 1,
+			numShards: numShards || 1,
+			parameterGroupName: 'default.memorydb-redis6', // exists by default in the account [?]
+			securityGroupIds: securityGroups.map(group => group.securityGroupId),
+			subnetGroupName: subnetGroup.ref,
+			tlsEnabled: true,
+		})
+
+		cluster.node.addDependency(subnetGroup)
+
+		this.cluster = cluster
+	}
+}

--- a/packages/@prototype/live-data-cache/src/LiveDataCache/index.ts
+++ b/packages/@prototype/live-data-cache/src/LiveDataCache/index.ts
@@ -15,29 +15,36 @@
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
 import { Construct } from 'constructs'
-import { aws_opensearchservice as opensearchservice, aws_elasticache as elasticache } from 'aws-cdk-lib'
+import { aws_opensearchservice as opensearchservice, aws_memorydb as memorydb } from 'aws-cdk-lib'
 import { OpenSearchCluster, OpenSearchClusterProps } from './OpenSearchCluster'
-import { RedisCluster, RedisClusterProps } from './RedisCluster'
+import { MemoryDBCluster, MemoryDBClusterProps } from './MemoryDBCluster'
+// import { memoryDBCluster, memoryDBClusterProps } from './memoryDBCluster'
 
 export interface LiveDataCacheProps {
-	readonly redisClusterProps: RedisClusterProps
+	readonly memoryDBClusterProps: MemoryDBClusterProps
 	readonly openSearchClusterProps: OpenSearchClusterProps
+	// readonly memoryDBClusterProps: memoryDBClusterProps
 }
 
 export class LiveDataCache extends Construct {
 	readonly openSearchDomain: opensearchservice.IDomain
 
-	readonly redisCluster: elasticache.CfnCacheCluster
+	readonly memoryDBCluster: memorydb.CfnCluster
+
+	// readonly memoryDBCluster: memorydb.CfnCluster
 
 	constructor (scope: Construct, id: string, props: LiveDataCacheProps) {
 		super(scope, id)
 
-		const { redisClusterProps, openSearchClusterProps } = props
+		const { memoryDBClusterProps, openSearchClusterProps } = props
 
 		const openSearchCluster = new OpenSearchCluster(this, 'OpenSearchCluster', openSearchClusterProps)
 		this.openSearchDomain = openSearchCluster.domain
 
-		const ecCluster = new RedisCluster(this, 'RedisCluster', redisClusterProps)
-		this.redisCluster = ecCluster.redisCluster
+		const memoryDBCluster = new MemoryDBCluster(this, 'MemoryDBCluster', memoryDBClusterProps)
+		this.memoryDBCluster = memoryDBCluster.cluster
+
+		// const ecCluster = new memoryDBCluster(this, 'memoryDBCluster', memoryDBClusterProps)
+		// this.memoryDBCluster = ecCluster.memoryDBCluster
 	}
 }

--- a/packages/@prototype/monitoring/src/Monitoring/assets/pm2.json
+++ b/packages/@prototype/monitoring/src/Monitoring/assets/pm2.json
@@ -2,7 +2,7 @@
     "apps": [
         {
             "name": "redis-commander",
-            "script": "npx redis-commander --redis-host __REDIS_HOST__ --redis-port 6379 --address 0.0.0.0 --port 6380"
+            "script": "npx redis-commander --redis-host __MEMORYDB_HOST__ --redis-port 6379 --address 0.0.0.0 --port 6380"
         }
     ]
 }

--- a/packages/@prototype/monitoring/src/Monitoring/index.ts
+++ b/packages/@prototype/monitoring/src/Monitoring/index.ts
@@ -23,7 +23,7 @@ import * as path from 'path'
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface MonitoringProps {
     readonly esEndpoint: string
-    readonly redisEndpoint: string
+    readonly memoryDBEndpoint: string
     readonly cognitoEndpoint: string
     readonly vpc: ec2.IVpc
     readonly securityGroup: ec2.ISecurityGroup
@@ -146,17 +146,17 @@ export class Monitoring extends Construct {
 			}),
 		)
 
-		let { esEndpoint, cognitoEndpoint, redisEndpoint } = props
+		let { esEndpoint, cognitoEndpoint, memoryDBEndpoint } = props
 		esEndpoint = esEndpoint.replace('https://', '')
 		cognitoEndpoint = cognitoEndpoint.replace('https://', '')
-		redisEndpoint = redisEndpoint.replace('https://', '')
+		memoryDBEndpoint = memoryDBEndpoint.replace('https://', '')
 
 		let nginxConfString = fs.readFileSync(path.join(__dirname, './assets/nginx.conf'), { encoding: 'utf-8' })
 		nginxConfString = nginxConfString.replace('__ES_ENDPOINT__', esEndpoint)
 		nginxConfString = nginxConfString.replace('__INTERNAL_COGNITO_ENDPOINT__', cognitoEndpoint)
 
 		let redisCommanderPm2Config = fs.readFileSync(path.join(__dirname, './assets/pm2.json'), { encoding: 'utf-8' })
-		redisCommanderPm2Config = redisCommanderPm2Config.replace('__REDIS_HOST__', redisEndpoint)
+		redisCommanderPm2Config = redisCommanderPm2Config.replace('__MEMORYDB_HOST__', memoryDBEndpoint)
 
 		const resourceConfigs = [
 			{

--- a/packages/@prototype/networking/README.md
+++ b/packages/@prototype/networking/README.md
@@ -9,7 +9,7 @@ The following resources are being created:
 * `vpc` - a new VPC with
 	* `PUBLIC`, `PRIVATE` and `ISOLATED` subnets
 	* 1 NAT Gateway
-	* security groups for `DMZ`, `Lambdas`, `RedisCluster` (including OPENSEARCH)
+	* security groups for `DMZ`, `Lambdas`, `memoryDBCluster` (including OPENSEARCH)
 	* ingress rules setup to provide communication between artifacts residing in each security group
 	* a `Bastion` instance to be able to `ssh tunnel` to the database from a developer's machine
 

--- a/packages/@prototype/order-manager/src/OrderManager/OrderManagerHandler/index.ts
+++ b/packages/@prototype/order-manager/src/OrderManager/OrderManagerHandler/index.ts
@@ -15,7 +15,7 @@
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
 import { Construct } from 'constructs'
-import { Duration, aws_lambda as lambda, aws_iam as iam, aws_stepfunctions as stepfunctions, aws_ec2 as ec2, aws_elasticache as elasticache, aws_dynamodb as ddb } from 'aws-cdk-lib'
+import { Duration, aws_lambda as lambda, aws_iam as iam, aws_stepfunctions as stepfunctions, aws_ec2 as ec2, aws_memorydb as memorydb, aws_dynamodb as ddb } from 'aws-cdk-lib'
 import { Networking } from '@prototype/networking'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
 import { namespaced } from '@aws-play/cdk-core'
@@ -32,7 +32,7 @@ interface Dependencies extends DeclaredLambdaDependencies {
 	readonly orderOrchestrator: stepfunctions.IStateMachine
 	readonly privateVpc: ec2.IVpc
 	readonly vpcNetworking: Networking
-	readonly redisCluster: elasticache.CfnCacheCluster
+	readonly memoryDBCluster: memorydb.CfnCluster
 	readonly lambdaLayers: { [key: string]: lambda.ILayerVersion, }
 }
 
@@ -45,7 +45,7 @@ export class OrderManagerHandlerLambda extends DeclaredLambdaFunction<Environmen
 			orderOrchestrator,
 			privateVpc,
 			vpcNetworking,
-			redisCluster,
+			memoryDBCluster,
 			lambdaLayers,
 		} = props.dependencies
 
@@ -56,8 +56,8 @@ export class OrderManagerHandlerLambda extends DeclaredLambdaFunction<Environmen
 			dependencies: props.dependencies,
 			timeout: Duration.seconds(120),
 			environment: {
-				REDIS_HOST: redisCluster.attrRedisEndpointAddress,
-				REDIS_PORT: redisCluster.attrRedisEndpointPort,
+				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
+				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
 				ORDER_TABLE: orderTable.tableName,
 				ORDER_ORCHESTRATOR_STATE_MACHINE: orderOrchestrator.stateMachineArn,
 				ORDER_SERVICE_NAME: SERVICE_NAME.ORDER_SERVICE,

--- a/packages/@prototype/order-manager/src/OrderManager/OrderManagerHelper/index.ts
+++ b/packages/@prototype/order-manager/src/OrderManager/OrderManagerHelper/index.ts
@@ -15,7 +15,7 @@
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
 import { Construct } from 'constructs'
-import { Duration, aws_lambda as lambda, aws_iam as iam, aws_ec2 as ec2, aws_elasticache as elasticache, aws_dynamodb as ddb, aws_events as events } from 'aws-cdk-lib'
+import { Duration, aws_lambda as lambda, aws_iam as iam, aws_ec2 as ec2, aws_memorydb as memorydb, aws_dynamodb as ddb, aws_events as events } from 'aws-cdk-lib'
 import { Networking } from '@prototype/networking'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
 import { namespaced } from '@aws-play/cdk-core'
@@ -32,7 +32,7 @@ interface Dependencies extends DeclaredLambdaDependencies {
 	readonly eventBus: events.EventBus
 	readonly privateVpc: ec2.IVpc
 	readonly vpcNetworking: Networking
-	readonly redisCluster: elasticache.CfnCacheCluster
+	readonly memoryDBCluster: memorydb.CfnCluster
 	readonly lambdaLayers: { [key: string]: lambda.ILayerVersion, }
 }
 
@@ -46,7 +46,7 @@ export class OrderManagerHelperLambda extends DeclaredLambdaFunction<Environment
 			privateVpc,
 			lambdaLayers,
 			vpcNetworking,
-			redisCluster,
+			memoryDBCluster,
 		} = props.dependencies
 
 		const declaredProps: TDeclaredProps = {
@@ -56,8 +56,8 @@ export class OrderManagerHelperLambda extends DeclaredLambdaFunction<Environment
 			dependencies: props.dependencies,
 			timeout: Duration.seconds(120),
 			environment: {
-				REDIS_HOST: redisCluster.attrRedisEndpointAddress,
-				REDIS_PORT: redisCluster.attrRedisEndpointPort,
+				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
+				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
 				ORDER_TABLE: orderTable.tableName,
 				EVENT_BUS: eventBus.eventBusArn,
 				SERVICE_NAME: SERVICE_NAME.ORDER_MANAGER,

--- a/packages/@prototype/order-manager/src/OrderManager/index.ts
+++ b/packages/@prototype/order-manager/src/OrderManager/index.ts
@@ -15,7 +15,7 @@
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
 import { Construct } from 'constructs'
-import { aws_events as events, aws_events_targets as events_targets, aws_dynamodb as ddb, aws_lambda as lambda, aws_stepfunctions as stepfunctions, aws_apigateway as apigw, aws_ec2 as ec2, aws_elasticache as elasticache } from 'aws-cdk-lib'
+import { aws_events as events, aws_events_targets as events_targets, aws_dynamodb as ddb, aws_lambda as lambda, aws_stepfunctions as stepfunctions, aws_apigateway as apigw, aws_ec2 as ec2, aws_memorydb as memorydb } from 'aws-cdk-lib'
 import { Networking } from '@prototype/networking'
 import { SERVICE_NAME } from '@prototype/common'
 import { OrderManagerHandlerLambda } from './OrderManagerHandler'
@@ -32,7 +32,7 @@ export interface OrderManagerStackProps {
 	readonly providerApiUrls: {[key: string]: apigw.RestApi, }
 	readonly privateVpc: ec2.IVpc
 	readonly vpcNetworking: Networking
-	readonly redisCluster: elasticache.CfnCacheCluster
+	readonly memoryDBCluster: memorydb.CfnCluster
 	readonly lambdaLayers: { [key: string]: lambda.ILayerVersion, }
 	readonly orderManagerSettings: { [key: string]: string | number | boolean, }
 }
@@ -54,7 +54,7 @@ export class OrderManagerStack extends Construct {
 			providerApiUrls,
 			privateVpc,
 			vpcNetworking,
-			redisCluster,
+			memoryDBCluster,
 			lambdaLayers,
 			orderManagerSettings,
 			demographicAreaProviderEngineSettings,
@@ -66,7 +66,7 @@ export class OrderManagerStack extends Construct {
 				eventBus,
 				privateVpc,
 				vpcNetworking,
-				redisCluster,
+				memoryDBCluster,
 				lambdaLayers,
 			},
 		})
@@ -91,7 +91,7 @@ export class OrderManagerStack extends Construct {
 				orderTable,
 				privateVpc,
 				vpcNetworking,
-				redisCluster,
+				memoryDBCluster,
 				lambdaLayers,
 				orderOrchestrator: this.orderManagerStepFunction,
 			},

--- a/packages/@prototype/provider-impl/src/ExamplePollingProvider/index.ts
+++ b/packages/@prototype/provider-impl/src/ExamplePollingProvider/index.ts
@@ -15,7 +15,7 @@
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
 import { Construct } from 'constructs'
-import { aws_events as events, aws_sqs as sqs, aws_elasticache as elasticache } from 'aws-cdk-lib'
+import { aws_events as events, aws_sqs as sqs, aws_memorydb as memorydb } from 'aws-cdk-lib'
 import { PollingProviderBase } from '@prototype/provider'
 import { VpcLambdaProps } from '@prototype/lambda-common'
 import { ExamplePollingLambda } from './lambdas/ExamplePolling'
@@ -29,7 +29,7 @@ export interface ExamplePollingProviderProps extends VpcLambdaProps {
 	readonly eventBus: events.IEventBus
 	readonly externalProviderMockUrl: string
 	readonly externalProviderSecretName: string
-	readonly redisCluster: elasticache.CfnCacheCluster
+	readonly memoryDBCluster: memorydb.CfnCluster
 }
 
 export class ExamplePollingProvider extends PollingProviderBase {
@@ -42,7 +42,7 @@ export class ExamplePollingProvider extends PollingProviderBase {
 			layers,
 			externalProviderMockUrl,
 			externalProviderSecretName,
-			redisCluster,
+			memoryDBCluster,
 		} = props
 
 		const pollingLambdaCreator = (queue: sqs.IQueue): ExamplePollingLambda => {
@@ -55,7 +55,7 @@ export class ExamplePollingProvider extends PollingProviderBase {
 					pendingOrdersQueue: queue,
 					externalProviderMockUrl,
 					externalProviderSecretName,
-					redisCluster,
+					memoryDBCluster,
 				},
 			})
 		}
@@ -70,7 +70,7 @@ export class ExamplePollingProvider extends PollingProviderBase {
 					pendingOrdersQueue: queue,
 					externalProviderMockUrl,
 					externalProviderSecretName,
-					redisCluster,
+					memoryDBCluster,
 				},
 			})
 		}
@@ -83,7 +83,7 @@ export class ExamplePollingProvider extends PollingProviderBase {
 				lambdaLayers: [layers.lambdaUtilsLayer, layers.lambdaInsightsLayer, layers.redisClientLayer],
 				externalProviderMockUrl,
 				externalProviderSecretName,
-				redisCluster,
+				memoryDBCluster,
 			},
 		})
 
@@ -95,7 +95,7 @@ export class ExamplePollingProvider extends PollingProviderBase {
 				lambdaLayers: [layers.lambdaUtilsLayer, layers.lambdaInsightsLayer, layers.redisClientLayer],
 				externalProviderMockUrl,
 				externalProviderSecretName,
-				redisCluster,
+				memoryDBCluster,
 			},
 		})
 

--- a/packages/@prototype/provider-impl/src/ExamplePollingProvider/lambdas/CancelOrder/index.ts
+++ b/packages/@prototype/provider-impl/src/ExamplePollingProvider/lambdas/CancelOrder/index.ts
@@ -15,7 +15,7 @@
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
 import { Construct } from 'constructs'
-import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_secretsmanager as secretsmanager, aws_events as events, aws_elasticache as elasticache, aws_iam as iam } from 'aws-cdk-lib'
+import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_secretsmanager as secretsmanager, aws_events as events, aws_memorydb as memorydb, aws_iam as iam } from 'aws-cdk-lib'
 import { namespaced } from '@aws-play/cdk-core'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
 import { LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
@@ -23,8 +23,8 @@ import { SERVICE_NAME, PROVIDER_NAME } from '@prototype/common'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface Environment extends DeclaredLambdaEnvironment {
-	readonly REDIS_HOST: string
-	readonly REDIS_PORT: string
+	readonly MEMORYDB_HOST: string
+	readonly MEMORYDB_PORT: string
 	readonly EXTERNAL_PROVIDER_URL: string
 	readonly EXTERNAL_PROVIDER_SECRETNAME: string
 	readonly EVENT_BUS: string
@@ -39,7 +39,7 @@ interface Dependencies extends DeclaredLambdaDependencies {
 	readonly eventBus: events.IEventBus
 	readonly externalProviderMockUrl: string
 	readonly externalProviderSecretName: string
-	readonly redisCluster: elasticache.CfnCacheCluster
+	readonly memoryDBCluster: memorydb.CfnCluster
 }
 
 type TDeclaredProps = DeclaredLambdaProps<Environment, Dependencies>
@@ -51,7 +51,7 @@ export class CancelOrderLambda extends DeclaredLambdaFunction<Environment, Depen
 			lambdaSecurityGroups,
 			lambdaLayers,
 			eventBus,
-			redisCluster,
+			memoryDBCluster,
 			externalProviderSecretName,
 			externalProviderMockUrl,
 		} = props.dependencies
@@ -65,8 +65,8 @@ export class CancelOrderLambda extends DeclaredLambdaFunction<Environment, Depen
 			dependencies: props.dependencies,
 			timeout: Duration.seconds(30),
 			environment: {
-				REDIS_HOST: redisCluster.attrRedisEndpointAddress,
-				REDIS_PORT: redisCluster.attrRedisEndpointPort,
+				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
+				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
 				EXTERNAL_PROVIDER_URL: externalProviderMockUrl,
 				EXTERNAL_PROVIDER_SECRETNAME: externalProviderSecretName,
 				EVENT_BUS: eventBus.eventBusName,

--- a/packages/@prototype/provider-impl/src/ExamplePollingProvider/lambdas/GetOrderStatus/index.ts
+++ b/packages/@prototype/provider-impl/src/ExamplePollingProvider/lambdas/GetOrderStatus/index.ts
@@ -15,7 +15,7 @@
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
 import { Construct } from 'constructs'
-import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_secretsmanager as secretsmanager, aws_events as events, aws_iam as iam, aws_elasticache as elasticache } from 'aws-cdk-lib'
+import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_secretsmanager as secretsmanager, aws_events as events, aws_iam as iam, aws_memorydb as memorydb } from 'aws-cdk-lib'
 import { namespaced } from '@aws-play/cdk-core'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
 import { LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
@@ -23,8 +23,8 @@ import { SERVICE_NAME, PROVIDER_NAME } from '@prototype/common'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface Environment extends DeclaredLambdaEnvironment {
-	readonly REDIS_HOST: string
-	readonly REDIS_PORT: string
+	readonly MEMORYDB_HOST: string
+	readonly MEMORYDB_PORT: string
 	readonly EXTERNAL_PROVIDER_URL: string
 	readonly EXTERNAL_PROVIDER_SECRETNAME: string
 	readonly EVENT_BUS: string
@@ -39,7 +39,7 @@ interface Dependencies extends DeclaredLambdaDependencies {
 	readonly eventBus: events.IEventBus
 	readonly externalProviderMockUrl: string
 	readonly externalProviderSecretName: string
-	readonly redisCluster: elasticache.CfnCacheCluster
+	readonly memoryDBCluster: memorydb.CfnCluster
 }
 
 type TDeclaredProps = DeclaredLambdaProps<Environment, Dependencies>
@@ -51,7 +51,7 @@ export class GetOrderStatusLambda extends DeclaredLambdaFunction<Environment, De
 			lambdaSecurityGroups,
 			lambdaLayers,
 			eventBus,
-			redisCluster,
+			memoryDBCluster,
 			externalProviderMockUrl,
 			externalProviderSecretName,
 		} = props.dependencies
@@ -65,8 +65,8 @@ export class GetOrderStatusLambda extends DeclaredLambdaFunction<Environment, De
 			dependencies: props.dependencies,
 			timeout: Duration.seconds(30),
 			environment: {
-				REDIS_HOST: redisCluster.attrRedisEndpointAddress,
-				REDIS_PORT: redisCluster.attrRedisEndpointPort,
+				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
+				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
 				EXTERNAL_PROVIDER_URL: externalProviderMockUrl,
 				EXTERNAL_PROVIDER_SECRETNAME: externalProviderSecretName,
 				EVENT_BUS: eventBus.eventBusName,

--- a/packages/@prototype/provider-impl/src/ExamplePollingProvider/lambdas/RequestOrderFulfillment/index.ts
+++ b/packages/@prototype/provider-impl/src/ExamplePollingProvider/lambdas/RequestOrderFulfillment/index.ts
@@ -15,7 +15,7 @@
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
 import { Construct } from 'constructs'
-import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_events as events, aws_elasticache as elasticache, aws_secretsmanager as secretsmanager, aws_sqs as sqs, aws_iam as iam } from 'aws-cdk-lib'
+import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_events as events, aws_memorydb as memorydb, aws_secretsmanager as secretsmanager, aws_sqs as sqs, aws_iam as iam } from 'aws-cdk-lib'
 import { namespaced } from '@aws-play/cdk-core'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
 import { LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
@@ -23,8 +23,8 @@ import { SERVICE_NAME, PROVIDER_NAME } from '@prototype/common'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface Environment extends DeclaredLambdaEnvironment {
-	readonly REDIS_HOST: string
-	readonly REDIS_PORT: string
+	readonly MEMORYDB_HOST: string
+	readonly MEMORYDB_PORT: string
 	readonly EXTERNAL_PROVIDER_URL: string
 	readonly EXTERNAL_PROVIDER_SECRETNAME: string
 	readonly EVENT_BUS: string
@@ -41,7 +41,7 @@ interface Dependencies extends DeclaredLambdaDependencies {
 	readonly pendingOrdersQueue: sqs.IQueue
 	readonly externalProviderMockUrl: string
 	readonly externalProviderSecretName: string
-	readonly redisCluster: elasticache.CfnCacheCluster
+	readonly memoryDBCluster: memorydb.CfnCluster
 }
 
 type TDeclaredProps = DeclaredLambdaProps<Environment, Dependencies>
@@ -54,7 +54,7 @@ export class RequestOrderFulfillmentLambda extends DeclaredLambdaFunction<Enviro
 			lambdaLayers,
 			eventBus,
 			pendingOrdersQueue,
-			redisCluster,
+			memoryDBCluster,
 			externalProviderMockUrl,
 			externalProviderSecretName,
 		} = props.dependencies
@@ -68,8 +68,8 @@ export class RequestOrderFulfillmentLambda extends DeclaredLambdaFunction<Enviro
 			dependencies: props.dependencies,
 			timeout: Duration.seconds(30),
 			environment: {
-				REDIS_HOST: redisCluster.attrRedisEndpointAddress,
-				REDIS_PORT: redisCluster.attrRedisEndpointPort,
+				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
+				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
 				EXTERNAL_PROVIDER_URL: externalProviderMockUrl,
 				EXTERNAL_PROVIDER_SECRETNAME: externalProviderSecretName,
 				EVENT_BUS: eventBus.eventBusName,

--- a/packages/@prototype/provider-impl/src/ExampleWebhookProvider/index.ts
+++ b/packages/@prototype/provider-impl/src/ExampleWebhookProvider/index.ts
@@ -15,7 +15,7 @@
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
 import { Construct } from 'constructs'
-import { aws_events as events, custom_resources as cr, aws_elasticache as elasticache } from 'aws-cdk-lib'
+import { aws_events as events, custom_resources as cr, aws_memorydb as memorydb } from 'aws-cdk-lib'
 import { WebhookProviderBase } from '@prototype/provider'
 import { VpcLambdaProps } from '@prototype/lambda-common'
 import { ExampleCallbackLambda } from './lambdas/ExampleCallback'
@@ -27,7 +27,7 @@ import { GetOrderStatusLambda } from './lambdas/GetOrderStatus'
 export interface ExampleWebhookProviderProps extends VpcLambdaProps {
 	readonly webhookProviderSettings: { [key: string]: string | number, }
 	readonly eventBus: events.IEventBus
-	readonly redisCluster: elasticache.CfnCacheCluster
+	readonly memoryDBCluster: memorydb.CfnCluster
 	readonly externalProviderMockUrl: string
 	readonly externalProviderSecretName: string
 }
@@ -42,7 +42,7 @@ export class ExampleWebhookProvider extends WebhookProviderBase {
 			layers,
 			externalProviderMockUrl,
 			externalProviderSecretName,
-			redisCluster,
+			memoryDBCluster,
 		} = props
 
 		const callbackLambdaHandler = new ExampleCallbackLambda(scope, 'WebhookProvider-ExampleCallbackLambda', {
@@ -51,7 +51,7 @@ export class ExampleWebhookProvider extends WebhookProviderBase {
 				vpc,
 				lambdaSecurityGroups,
 				lambdaLayers: [layers.lambdaUtilsLayer, layers.lambdaInsightsLayer, layers.redisClientLayer],
-				redisCluster,
+				memoryDBCluster,
 			},
 		})
 
@@ -63,7 +63,7 @@ export class ExampleWebhookProvider extends WebhookProviderBase {
 				lambdaLayers: [layers.lambdaUtilsLayer, layers.lambdaInsightsLayer, layers.redisClientLayer],
 				externalProviderMockUrl,
 				externalProviderSecretName,
-				redisCluster,
+				memoryDBCluster,
 			},
 		})
 
@@ -75,7 +75,7 @@ export class ExampleWebhookProvider extends WebhookProviderBase {
 				lambdaLayers: [layers.lambdaUtilsLayer, layers.lambdaInsightsLayer, layers.redisClientLayer],
 				externalProviderMockUrl,
 				externalProviderSecretName,
-				redisCluster,
+				memoryDBCluster,
 			},
 		})
 
@@ -87,7 +87,7 @@ export class ExampleWebhookProvider extends WebhookProviderBase {
 				lambdaLayers: [layers.lambdaUtilsLayer, layers.lambdaInsightsLayer, layers.redisClientLayer],
 				externalProviderMockUrl,
 				externalProviderSecretName,
-				redisCluster,
+				memoryDBCluster,
 			},
 		})
 

--- a/packages/@prototype/provider-impl/src/ExampleWebhookProvider/lambdas/CancelOrder/index.ts
+++ b/packages/@prototype/provider-impl/src/ExampleWebhookProvider/lambdas/CancelOrder/index.ts
@@ -15,7 +15,7 @@
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
 import { Construct } from 'constructs'
-import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_secretsmanager as secretsmanager, aws_elasticache as elasticache, aws_events as events, aws_iam as iam } from 'aws-cdk-lib'
+import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_secretsmanager as secretsmanager, aws_memorydb as memorydb, aws_events as events, aws_iam as iam } from 'aws-cdk-lib'
 import { namespaced } from '@aws-play/cdk-core'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
 import { LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
@@ -23,8 +23,8 @@ import { SERVICE_NAME, PROVIDER_NAME } from '@prototype/common'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface Environment extends DeclaredLambdaEnvironment {
-	readonly REDIS_HOST: string
-	readonly REDIS_PORT: string
+	readonly MEMORYDB_HOST: string
+	readonly MEMORYDB_PORT: string
 	readonly EVENT_BUS: string
 	readonly SERVICE_NAME: string
 }
@@ -34,7 +34,7 @@ interface Dependencies extends DeclaredLambdaDependencies {
 	readonly lambdaSecurityGroups: ec2.ISecurityGroup[]
 	readonly lambdaLayers: lambda.ILayerVersion[]
 	readonly eventBus: events.IEventBus
-	readonly redisCluster: elasticache.CfnCacheCluster
+	readonly memoryDBCluster: memorydb.CfnCluster
 	readonly externalProviderMockUrl: string
 	readonly externalProviderSecretName: string
 }
@@ -48,7 +48,7 @@ export class CancelOrderLambda extends DeclaredLambdaFunction<Environment, Depen
 			lambdaSecurityGroups,
 			lambdaLayers,
 			eventBus,
-			redisCluster,
+			memoryDBCluster,
 			externalProviderMockUrl,
 			externalProviderSecretName,
 		} = props.dependencies
@@ -65,8 +65,8 @@ export class CancelOrderLambda extends DeclaredLambdaFunction<Environment, Depen
 				EVENT_BUS: eventBus.eventBusName,
 				SERVICE_NAME: SERVICE_NAME.EXAMPLE_WEBHOOK_PROVIDER_SERVICE,
 				PROVIDER_NAME: PROVIDER_NAME.EXAMPLE_WEBHOOK_PROVIDER,
-				REDIS_HOST: redisCluster.attrRedisEndpointAddress,
-				REDIS_PORT: redisCluster.attrRedisEndpointPort,
+				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
+				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
 				EXTERNAL_PROVIDER_URL: externalProviderMockUrl,
 				EXTERNAL_PROVIDER_SECRETNAME: externalProviderSecretName,
 			},

--- a/packages/@prototype/provider-impl/src/ExampleWebhookProvider/lambdas/ExampleCallback/index.ts
+++ b/packages/@prototype/provider-impl/src/ExampleWebhookProvider/lambdas/ExampleCallback/index.ts
@@ -15,7 +15,7 @@
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
 import { Construct } from 'constructs'
-import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_events as events, aws_elasticache as elasticache, aws_iam as iam } from 'aws-cdk-lib'
+import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_events as events, aws_memorydb as memorydb, aws_iam as iam } from 'aws-cdk-lib'
 import { namespaced } from '@aws-play/cdk-core'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
 import { LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
@@ -23,8 +23,8 @@ import { SERVICE_NAME, PROVIDER_NAME } from '@prototype/common'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface Environment extends DeclaredLambdaEnvironment {
-	readonly REDIS_HOST: string
-	readonly REDIS_PORT: string
+	readonly MEMORYDB_HOST: string
+	readonly MEMORYDB_PORT: string
 	readonly EVENT_BUS: string
 	readonly SERVICE_NAME: string
 }
@@ -34,7 +34,7 @@ interface Dependencies extends DeclaredLambdaDependencies {
 	readonly lambdaSecurityGroups: ec2.ISecurityGroup[]
 	readonly lambdaLayers: lambda.ILayerVersion[]
 	readonly eventBus: events.IEventBus
-	readonly redisCluster: elasticache.CfnCacheCluster
+	readonly memoryDBCluster: memorydb.CfnCluster
 }
 
 type TDeclaredProps = DeclaredLambdaProps<Environment, Dependencies>
@@ -46,7 +46,7 @@ export class ExampleCallbackLambda extends DeclaredLambdaFunction<Environment, D
 			lambdaSecurityGroups,
 			lambdaLayers,
 			eventBus,
-			redisCluster,
+			memoryDBCluster,
 		} = props.dependencies
 
 		const declaredProps: TDeclaredProps = {
@@ -56,8 +56,8 @@ export class ExampleCallbackLambda extends DeclaredLambdaFunction<Environment, D
 			dependencies: props.dependencies,
 			timeout: Duration.seconds(30),
 			environment: {
-				REDIS_HOST: redisCluster.attrRedisEndpointAddress,
-				REDIS_PORT: redisCluster.attrRedisEndpointPort,
+				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
+				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
 				EVENT_BUS: eventBus.eventBusName,
 				SERVICE_NAME: SERVICE_NAME.EXAMPLE_WEBHOOK_PROVIDER_SERVICE,
 				PROVIDER_NAME: PROVIDER_NAME.EXAMPLE_WEBHOOK_PROVIDER,

--- a/packages/@prototype/provider-impl/src/ExampleWebhookProvider/lambdas/GetOrderStatus/index.ts
+++ b/packages/@prototype/provider-impl/src/ExampleWebhookProvider/lambdas/GetOrderStatus/index.ts
@@ -15,7 +15,7 @@
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
 import { Construct } from 'constructs'
-import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_secretsmanager as secretsmanager, aws_elasticache as elasticache, aws_events as events, aws_iam as iam } from 'aws-cdk-lib'
+import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_secretsmanager as secretsmanager, aws_memorydb as memorydb, aws_events as events, aws_iam as iam } from 'aws-cdk-lib'
 import { namespaced } from '@aws-play/cdk-core'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
 import { LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
@@ -23,8 +23,8 @@ import { SERVICE_NAME, PROVIDER_NAME } from '@prototype/common'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface Environment extends DeclaredLambdaEnvironment {
-	readonly REDIS_HOST: string
-	readonly REDIS_PORT: string
+	readonly MEMORYDB_HOST: string
+	readonly MEMORYDB_PORT: string
 	readonly EVENT_BUS: string
 	readonly SERVICE_NAME: string
 }
@@ -34,7 +34,7 @@ interface Dependencies extends DeclaredLambdaDependencies {
 	readonly lambdaSecurityGroups: ec2.ISecurityGroup[]
 	readonly lambdaLayers: lambda.ILayerVersion[]
 	readonly eventBus: events.IEventBus
-	readonly redisCluster: elasticache.CfnCacheCluster
+	readonly memoryDBCluster: memorydb.CfnCluster
 	readonly externalProviderMockUrl: string
 	readonly externalProviderSecretName: string
 }
@@ -48,7 +48,7 @@ export class GetOrderStatusLambda extends DeclaredLambdaFunction<Environment, De
 			lambdaSecurityGroups,
 			lambdaLayers,
 			eventBus,
-			redisCluster,
+			memoryDBCluster,
 			externalProviderSecretName,
 			externalProviderMockUrl,
 		} = props.dependencies
@@ -65,8 +65,8 @@ export class GetOrderStatusLambda extends DeclaredLambdaFunction<Environment, De
 				EVENT_BUS: eventBus.eventBusName,
 				SERVICE_NAME: SERVICE_NAME.EXAMPLE_WEBHOOK_PROVIDER_SERVICE,
 				PROVIDER_NAME: PROVIDER_NAME.EXAMPLE_WEBHOOK_PROVIDER,
-				REDIS_HOST: redisCluster.attrRedisEndpointAddress,
-				REDIS_PORT: redisCluster.attrRedisEndpointPort,
+				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
+				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
 				EXTERNAL_PROVIDER_URL: externalProviderMockUrl,
 				EXTERNAL_PROVIDER_SECRETNAME: externalProviderSecretName,
 			},

--- a/packages/@prototype/provider-impl/src/ExampleWebhookProvider/lambdas/RequestOrderFulfillment/index.ts
+++ b/packages/@prototype/provider-impl/src/ExampleWebhookProvider/lambdas/RequestOrderFulfillment/index.ts
@@ -15,7 +15,7 @@
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
 import { Construct } from 'constructs'
-import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_events as events, aws_secretsmanager as secretsmanager, aws_elasticache as elasticache, aws_iam as iam } from 'aws-cdk-lib'
+import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_events as events, aws_secretsmanager as secretsmanager, aws_memorydb as memorydb, aws_iam as iam } from 'aws-cdk-lib'
 import { namespaced } from '@aws-play/cdk-core'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
 import { LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
@@ -23,8 +23,8 @@ import { SERVICE_NAME, PROVIDER_NAME } from '@prototype/common'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface Environment extends DeclaredLambdaEnvironment {
-	readonly REDIS_HOST: string
-	readonly REDIS_PORT: string
+	readonly MEMORYDB_HOST: string
+	readonly MEMORYDB_PORT: string
 	readonly EVENT_BUS: string
 	readonly SERVICE_NAME: string
 	readonly EXTERNAL_PROVIDER_URL: string
@@ -36,7 +36,7 @@ interface Dependencies extends DeclaredLambdaDependencies {
 	readonly lambdaSecurityGroups: ec2.ISecurityGroup[]
 	readonly lambdaLayers: lambda.ILayerVersion[]
 	readonly eventBus: events.IEventBus
-	readonly redisCluster: elasticache.CfnCacheCluster
+	readonly memoryDBCluster: memorydb.CfnCluster
 	readonly externalProviderMockUrl: string
 	readonly externalProviderSecretName: string
 }
@@ -52,14 +52,14 @@ export class RequestOrderFulfillmentLambda extends DeclaredLambdaFunction<Enviro
 			lambdaSecurityGroups,
 			lambdaLayers,
 			eventBus,
-			redisCluster,
+			memoryDBCluster,
 			externalProviderSecretName,
 			externalProviderMockUrl,
 		} = props.dependencies
 
 		const environmentVariables = {
-			REDIS_HOST: redisCluster.attrRedisEndpointAddress,
-			REDIS_PORT: redisCluster.attrRedisEndpointPort,
+			MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
+			MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
 			EXTERNAL_PROVIDER_URL: externalProviderMockUrl,
 			EXTERNAL_PROVIDER_SECRETNAME: externalProviderSecretName,
 			EVENT_BUS: eventBus.eventBusName,

--- a/packages/@prototype/simulator/src/SimulatorManagerStack/DestinationSimulatorLambda/DestinationStatusUpdateLambda/index.ts
+++ b/packages/@prototype/simulator/src/SimulatorManagerStack/DestinationSimulatorLambda/DestinationStatusUpdateLambda/index.ts
@@ -15,7 +15,7 @@
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
 import { Construct } from 'constructs'
-import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_events as events, aws_iam as iam, aws_elasticache as elasticache } from 'aws-cdk-lib'
+import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_events as events, aws_iam as iam, aws_memorydb as memorydb } from 'aws-cdk-lib'
 import { namespaced } from '@aws-play/cdk-core'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
 import { LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
@@ -23,8 +23,8 @@ import { SERVICE_NAME } from '@prototype/common'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface Environment extends DeclaredLambdaEnvironment {
-	readonly REDIS_HOST: string
-	readonly REDIS_PORT: string
+	readonly MEMORYDB_HOST: string
+	readonly MEMORYDB_PORT: string
 	readonly EVENT_BUS_NAME: string
 	readonly SERVICE_NAME: string
 }
@@ -32,7 +32,7 @@ interface Environment extends DeclaredLambdaEnvironment {
 interface Dependencies extends DeclaredLambdaDependencies {
 	readonly vpc: ec2.IVpc
 	readonly lambdaSecurityGroups: ec2.ISecurityGroup[]
-	readonly redisCluster: elasticache.CfnCacheCluster
+	readonly memoryDBCluster: memorydb.CfnCluster
 	readonly lambdaLayers: lambda.ILayerVersion[]
 	readonly eventBus: events.EventBus
 }
@@ -44,7 +44,7 @@ export class DestinationStatusUpdateLambda extends DeclaredLambdaFunction<Enviro
 		const {
 			vpc,
 			lambdaSecurityGroups,
-			redisCluster,
+			memoryDBCluster,
 			lambdaLayers,
 			eventBus,
 		} = props.dependencies
@@ -56,8 +56,8 @@ export class DestinationStatusUpdateLambda extends DeclaredLambdaFunction<Enviro
 			dependencies: props.dependencies,
 			timeout: Duration.seconds(30),
 			environment: {
-				REDIS_HOST: redisCluster.attrRedisEndpointAddress,
-				REDIS_PORT: redisCluster.attrRedisEndpointPort,
+				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
+				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
 				EVENT_BUS_NAME: eventBus.eventBusName,
 				SERVICE_NAME: SERVICE_NAME.DESTINATION_SERVICE,
 			},

--- a/packages/@prototype/simulator/src/SimulatorManagerStack/DestinationSimulatorLambda/index.ts
+++ b/packages/@prototype/simulator/src/SimulatorManagerStack/DestinationSimulatorLambda/index.ts
@@ -15,7 +15,7 @@
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
 import { Construct } from 'constructs'
-import { Duration, aws_dynamodb as ddb, aws_iam as iam, aws_ecs as ecs, aws_ec2 as ec2, aws_lambda as lambda, aws_cognito as cognito, aws_iot as iot, aws_stepfunctions as stepfunctions, aws_elasticache as elasticache, aws_events as events } from 'aws-cdk-lib'
+import { Duration, aws_dynamodb as ddb, aws_iam as iam, aws_ecs as ecs, aws_ec2 as ec2, aws_lambda as lambda, aws_cognito as cognito, aws_iot as iot, aws_stepfunctions as stepfunctions, aws_memorydb as memorydb, aws_events as events } from 'aws-cdk-lib'
 import { Networking } from '@prototype/networking'
 import { DeclaredLambdaFunction } from '@aws-play/cdk-lambda'
 import { namespaced } from '@aws-play/cdk-core'
@@ -45,7 +45,7 @@ export interface DestinationSimulatorProps {
 	readonly eventBus: events.EventBus
 	readonly privateVpc: ec2.IVpc
 	readonly vpcNetworking: Networking
-	readonly redisCluster: elasticache.CfnCacheCluster
+	readonly memoryDBCluster: memorydb.CfnCluster
 	readonly lambdaLayers: { [key: string]: lambda.ILayerVersion, }
 
 	readonly iotEndpointAddress: string
@@ -84,7 +84,7 @@ export class DestinationSimulatorLambda extends Construct {
 			securityGroup,
 			privateVpc,
 			vpcNetworking,
-			redisCluster,
+			memoryDBCluster,
 			lambdaLayers,
 			eventBus,
 			iotEndpointAddress,
@@ -172,7 +172,7 @@ export class DestinationSimulatorLambda extends Construct {
 				eventBus,
 				vpc: privateVpc,
 				lambdaSecurityGroups: [vpcNetworking.securityGroups.lambda],
-				redisCluster,
+				memoryDBCluster,
 				lambdaLayers: [
 					lambdaLayers.lambdaUtilsLayer,
 					lambdaLayers.redisClientLayer,

--- a/packages/@prototype/simulator/src/SimulatorManagerStack/OriginSimulatorLambda/OriginStatusUpdateLambda/index.ts
+++ b/packages/@prototype/simulator/src/SimulatorManagerStack/OriginSimulatorLambda/OriginStatusUpdateLambda/index.ts
@@ -15,7 +15,7 @@
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
 import { Construct } from 'constructs'
-import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_events as events, aws_iam as iam, aws_elasticache as elasticache } from 'aws-cdk-lib'
+import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_events as events, aws_iam as iam, aws_memorydb as memorydb } from 'aws-cdk-lib'
 import { namespaced } from '@aws-play/cdk-core'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
 import { LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
@@ -23,8 +23,8 @@ import { SERVICE_NAME } from '@prototype/common'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface Environment extends DeclaredLambdaEnvironment {
-	readonly REDIS_HOST: string
-	readonly REDIS_PORT: string
+	readonly MEMORYDB_HOST: string
+	readonly MEMORYDB_PORT: string
 	readonly EVENT_BUS_NAME: string
 	readonly SERVICE_NAME: string
 }
@@ -32,7 +32,7 @@ interface Environment extends DeclaredLambdaEnvironment {
 interface Dependencies extends DeclaredLambdaDependencies {
 	readonly vpc: ec2.IVpc
 	readonly lambdaSecurityGroups: ec2.ISecurityGroup[]
-	readonly redisCluster: elasticache.CfnCacheCluster
+	readonly memoryDBCluster: memorydb.CfnCluster
 	readonly lambdaLayers: lambda.ILayerVersion[]
 	readonly eventBus: events.EventBus
 }
@@ -44,7 +44,7 @@ export class OriginStatusUpdateLambda extends DeclaredLambdaFunction<Environment
 		const {
 			vpc,
 			lambdaSecurityGroups,
-			redisCluster,
+			memoryDBCluster,
 			lambdaLayers,
 			eventBus,
 		} = props.dependencies
@@ -56,8 +56,8 @@ export class OriginStatusUpdateLambda extends DeclaredLambdaFunction<Environment
 			dependencies: props.dependencies,
 			timeout: Duration.seconds(30),
 			environment: {
-				REDIS_HOST: redisCluster.attrRedisEndpointAddress,
-				REDIS_PORT: redisCluster.attrRedisEndpointPort,
+				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
+				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
 				EVENT_BUS_NAME: eventBus.eventBusName,
 				SERVICE_NAME: SERVICE_NAME.ORIGIN_SERVICE,
 			},

--- a/packages/@prototype/simulator/src/SimulatorManagerStack/OriginSimulatorLambda/index.ts
+++ b/packages/@prototype/simulator/src/SimulatorManagerStack/OriginSimulatorLambda/index.ts
@@ -15,7 +15,7 @@
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
 import { Construct } from 'constructs'
-import { Duration, aws_dynamodb as ddb, aws_iam as iam, aws_ecs as ecs, aws_ec2 as ec2, aws_lambda as lambda, aws_cognito as cognito, aws_iot as iot, aws_stepfunctions as stepfunctions, aws_elasticache as elasticache, aws_events as events, aws_events_targets as events_targets } from 'aws-cdk-lib'
+import { Duration, aws_dynamodb as ddb, aws_iam as iam, aws_ecs as ecs, aws_ec2 as ec2, aws_lambda as lambda, aws_cognito as cognito, aws_iot as iot, aws_stepfunctions as stepfunctions, aws_memorydb as memorydb, aws_events as events, aws_events_targets as events_targets } from 'aws-cdk-lib'
 import { Networking } from '@prototype/networking'
 import { DeclaredLambdaFunction } from '@aws-play/cdk-lambda'
 import { namespaced } from '@aws-play/cdk-core'
@@ -47,7 +47,7 @@ export interface OriginSimulatorProps {
 	readonly eventBus: events.EventBus
 	readonly privateVpc: ec2.IVpc
 	readonly vpcNetworking: Networking
-	readonly redisCluster: elasticache.CfnCacheCluster
+	readonly memoryDBCluster: memorydb.CfnCluster
 	readonly lambdaLayers: { [key: string]: lambda.ILayerVersion, }
 	readonly iotEndpointAddress: string
 }
@@ -83,7 +83,7 @@ export class OriginSimulatorLambda extends Construct {
 			securityGroup,
 			privateVpc,
 			vpcNetworking,
-			redisCluster,
+			memoryDBCluster,
 			lambdaLayers,
 			eventBus,
 			iotEndpointAddress,
@@ -131,8 +131,8 @@ export class OriginSimulatorLambda extends Construct {
 			architecture: lambda.Architecture.ARM_64,
 			timeout: Duration.seconds(120),
 			environment: {
-				REDIS_HOST: redisCluster.attrRedisEndpointAddress,
-				REDIS_PORT: redisCluster.attrRedisEndpointPort,
+				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
+				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
 				ORIGIN_TABLE: originTable.tableName,
 				ORIGIN_SIMULATIONS_TABLE_NAME: originSimulationsTable.tableName,
 				ORIGIN_STATS_TABLE_NAME: originStatsTable.tableName,
@@ -184,7 +184,7 @@ export class OriginSimulatorLambda extends Construct {
 				eventBus,
 				vpc: privateVpc,
 				lambdaSecurityGroups: [vpcNetworking.securityGroups.lambda],
-				redisCluster,
+				memoryDBCluster,
 				lambdaLayers: [
 					lambdaLayers.lambdaUtilsLayer,
 					lambdaLayers.redisClientLayer,

--- a/packages/@prototype/simulator/src/SimulatorManagerStack/StatisticsLambda/index.ts
+++ b/packages/@prototype/simulator/src/SimulatorManagerStack/StatisticsLambda/index.ts
@@ -15,7 +15,7 @@
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
 import { Construct } from 'constructs'
-import { Duration, Stack, aws_ec2 as ec2, aws_events as events, aws_events_targets as events_targets, aws_elasticache as elasticache, aws_lambda as lambda } from 'aws-cdk-lib'
+import { Duration, Stack, aws_ec2 as ec2, aws_events as events, aws_events_targets as events_targets, aws_memorydb as memorydb, aws_lambda as lambda } from 'aws-cdk-lib'
 import { Networking } from '@prototype/networking'
 import { DeclaredLambdaFunction } from '@aws-play/cdk-lambda'
 import { namespaced } from '@aws-play/cdk-core'
@@ -24,7 +24,7 @@ import { SERVICE_NAME, PROVIDER_NAME } from '@prototype/common'
 export interface StatisticsProps {
 	readonly privateVpc: ec2.IVpc
 	readonly vpcNetworking: Networking
-	readonly redisCluster: elasticache.CfnCacheCluster
+	readonly memoryDBCluster: memorydb.CfnCluster
 	readonly lambdaLayers: { [key: string]: lambda.ILayerVersion, }
 	readonly eventBus: events.EventBus
 }
@@ -38,7 +38,7 @@ export class StatisticsLambda extends Construct {
 		const stack = Stack.of(this)
 		const {
 			eventBus,
-			redisCluster,
+			memoryDBCluster,
 			privateVpc,
 			vpcNetworking,
 			lambdaLayers,
@@ -53,8 +53,8 @@ export class StatisticsLambda extends Construct {
 			architecture: lambda.Architecture.ARM_64,
 			timeout: Duration.seconds(120),
 			environment: {
-				REDIS_HOST: redisCluster.attrRedisEndpointAddress,
-				REDIS_PORT: redisCluster.attrRedisEndpointPort,
+				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
+				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
 				DISPATCH_ENGINE_SERVICE: SERVICE_NAME.DISPATCH_ENGINE,
 				ORDER_SERVICE_NAME: SERVICE_NAME.ORDER_SERVICE,
 				DRIVER_SERVICE_NAME: SERVICE_NAME.DRIVER_SERVICE,

--- a/packages/@prototype/simulator/src/SimulatorManagerStack/index.ts
+++ b/packages/@prototype/simulator/src/SimulatorManagerStack/index.ts
@@ -15,7 +15,7 @@
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
 import { Construct } from 'constructs'
-import { aws_ec2 as ec2, aws_ecs as ecs, aws_events as events, aws_dynamodb as ddb, aws_cognito as cognito, aws_iot as iot, aws_lambda as lambda, aws_elasticache as elasticache } from 'aws-cdk-lib'
+import { aws_ec2 as ec2, aws_ecs as ecs, aws_events as events, aws_dynamodb as ddb, aws_cognito as cognito, aws_iot as iot, aws_lambda as lambda, aws_memorydb as memorydb } from 'aws-cdk-lib'
 import * as api from '@aws-play/cdk-apigateway'
 import { Networking } from '@prototype/networking'
 import { SimulatorManagerLambda } from './SimulatorManagerLambda'
@@ -72,7 +72,7 @@ export interface SimulatorManagerStackProps {
 
 	readonly privateVpc: ec2.IVpc
 	readonly vpcNetworking: Networking
-	readonly redisCluster: elasticache.CfnCacheCluster
+	readonly memoryDBCluster: memorydb.CfnCluster
 	readonly lambdaLayers: { [key: string]: lambda.ILayerVersion, }
 
 	readonly iotEndpointAddress: string
@@ -120,7 +120,7 @@ export class SimulatorManagerStack extends Construct {
 			destinationUserPassword,
 			privateVpc,
 			vpcNetworking,
-			redisCluster,
+			memoryDBCluster,
 			lambdaLayers,
 			dispatcherAssignmentsTable,
 			instantDeliveryProviderOrdersTable,
@@ -169,7 +169,7 @@ export class SimulatorManagerStack extends Construct {
 			privateVpc,
 			vpcNetworking,
 			lambdaLayers,
-			redisCluster,
+			memoryDBCluster,
 			eventBus,
 			iotEndpointAddress,
 		})
@@ -192,7 +192,7 @@ export class SimulatorManagerStack extends Construct {
 			privateVpc,
 			vpcNetworking,
 			lambdaLayers,
-			redisCluster,
+			memoryDBCluster,
 			eventBus,
 			iotEndpointAddress,
 		})
@@ -206,7 +206,7 @@ export class SimulatorManagerStack extends Construct {
 		const statisticsLambdaSimulator = new StatisticsLambda(this, 'StatsSimulatorLambda', {
 			eventBus,
 			privateVpc,
-			redisCluster,
+			memoryDBCluster,
 			lambdaLayers,
 			vpcNetworking,
 		})

--- a/prototype/infra/config/test.json
+++ b/prototype/infra/config/test.json
@@ -11,7 +11,7 @@
 	},
 	"geoTrackingApiKeySecretName": "",
 	"openSearchConfig": {},
-	"redisConfig": {},
+	"memoryDBConfig": {},
 	"simulatorConfig": {},
 	"kinesisConfig": {
 		"driverLocationUpdateMaxBatchingWindowMs": 5000,

--- a/prototype/infra/lib/stack/nested/BackendBaseNestedStack/index.ts
+++ b/prototype/infra/lib/stack/nested/BackendBaseNestedStack/index.ts
@@ -29,7 +29,7 @@ export interface BackendBaseNestedStackProps extends NestedStackProps {
 	readonly adminRole: iam.IRole
 	readonly vpcNetworkConfig: { [key: string]: [{ cidr: string, port: number, }], }
 	readonly openSearchConfig: { [key: string]: string | number, }
-	readonly redisConfig: { [key: string]: string | number, }
+	readonly memoryDBConfig: { [key: string]: string | number, }
 }
 
 /**
@@ -51,7 +51,7 @@ export class BackendBaseNestedStack extends NestedStack {
 			adminRole,
 			vpcNetworkConfig,
 			openSearchConfig,
-			redisConfig,
+			memoryDBConfig,
 		} = props
 
 		this.vpcNetworking = new Networking(this, 'Networking', {
@@ -74,9 +74,10 @@ export class BackendBaseNestedStack extends NestedStack {
 				authenticatedUserRole: internalIdentityAuthenticatedRole,
 				adminRole,
 			},
-			redisClusterProps: {
-				numNodes: 3,
-				nodeType: redisConfig.instanceType as string,
+			memoryDBClusterProps: {
+				numShards: memoryDBConfig.numShards as number,
+				numReplicasPerShard: memoryDBConfig.numReplicasPerShard as number,
+				nodeType: memoryDBConfig.instanceType as string,
 				securityGroups: [securityGroups.redis],
 				vpc,
 			},

--- a/prototype/infra/lib/stack/nested/MicroServiceStack/index.ts
+++ b/prototype/infra/lib/stack/nested/MicroServiceStack/index.ts
@@ -16,7 +16,7 @@
  *********************************************************************************************************************/
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { Construct } from 'constructs'
-import { NestedStack, NestedStackProps, Environment, aws_apigateway as apigw, aws_lambda as lambda, aws_kinesis as kinesis, aws_dynamodb as ddb, aws_cognito as cognito, aws_events as events, aws_elasticache as elasticache, aws_opensearchservice as opensearchservice, aws_ec2 as ec2 } from 'aws-cdk-lib'
+import { NestedStack, NestedStackProps, Environment, aws_apigateway as apigw, aws_lambda as lambda, aws_kinesis as kinesis, aws_dynamodb as ddb, aws_cognito as cognito, aws_events as events, aws_memorydb as memorydb, aws_opensearchservice as opensearchservice, aws_ec2 as ec2 } from 'aws-cdk-lib'
 import { namespaced } from '@aws-play/cdk-core'
 import { RestApi } from '@aws-play/cdk-apigateway'
 import { LambdaUtilsLayer, OpenSearchClientLayer, RedisClientLayer, LambdaInsightsLayer } from '@prototype/lambda-common'
@@ -30,10 +30,10 @@ export interface MicroServiceStackProps extends NestedStackProps {
 	readonly demographicAreaDispatchSettings: ddb.ITable
 	readonly userPool: cognito.IUserPool
 	readonly vpcNetworking: Networking
-	readonly redisCluster: elasticache.CfnCacheCluster
+	readonly memoryDBCluster: memorydb.CfnCluster
 	readonly openSearchDomain: opensearchservice.IDomain
 	readonly driverDataIngestStream: kinesis.IStream
-	readonly redisConfig: { [key: string]: string | number, }
+	readonly memoryDBConfig: { [key: string]: string | number, }
 	readonly kinesisConfig: { [key: string]: string | number | boolean, }
 	readonly env?: Environment
 }
@@ -61,10 +61,10 @@ export class MicroServiceStack extends NestedStack {
 			vpc,
 			userPool,
 			vpcNetworking,
-			redisCluster,
+			memoryDBCluster,
 			openSearchDomain,
 			driverDataIngestStream,
-			redisConfig,
+			memoryDBConfig,
 			kinesisConfig,
 			env,
 		} = props
@@ -104,11 +104,11 @@ export class MicroServiceStack extends NestedStack {
 		const lambdaFunctions = new LambdaFunctions(this, 'LambdaFunctions-Stack', {
 			vpc,
 			lambdaSecurityGroups: [securityGroups.lambda],
-			redisCluster,
+			memoryDBCluster,
 			lambdaLayers,
 			cleanupScheduleMins: 1,
 			driverDataIngestStream: kinesis.Stream.fromStreamArn(this, 'DriverDataIngestStreamMS', driverDataIngestStream.streamArn),
-			driverLocationUpdateTTLInMs: redisConfig.driverLocationUpdateTTLInMS as number,
+			driverLocationUpdateTTLInMs: memoryDBConfig.driverLocationUpdateTTLInMS as number,
 			openSearchDomain,
 			eventBus,
 			geofencingBatchSize: kinesisConfig.geofencingBatchSize as number,
@@ -129,7 +129,7 @@ export class MicroServiceStack extends NestedStack {
 			lambdaLayers,
 			vpc,
 			lambdaSecurityGroups: [securityGroups.lambda],
-			redisCluster,
+			memoryDBCluster,
 			geoPolygonTable,
 			// for this API only the dispatcher settings table is being used
 			demographicAreaDispatchSettings,
@@ -143,7 +143,7 @@ export class MicroServiceStack extends NestedStack {
 			lambdaLayers,
 			vpc,
 			lambdaSecurityGroups: [securityGroups.lambda],
-			redisCluster,
+			memoryDBCluster,
 			eventBus,
 		})
 

--- a/prototype/infra/lib/stack/nested/MonitoringNestedStack/index.ts
+++ b/prototype/infra/lib/stack/nested/MonitoringNestedStack/index.ts
@@ -15,7 +15,7 @@
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
 import { Construct } from 'constructs'
-import { Stack, NestedStack, NestedStackProps, aws_ec2 as ec2, aws_opensearchservice as opensearchservice, aws_elasticache as elasticache, aws_cognito as cognito } from 'aws-cdk-lib'
+import { Stack, NestedStack, NestedStackProps, aws_ec2 as ec2, aws_opensearchservice as opensearchservice, aws_memorydb as memorydb, aws_cognito as cognito } from 'aws-cdk-lib'
 import { Networking } from '@prototype/networking'
 import { Monitoring } from '@prototype/monitoring'
 
@@ -23,7 +23,7 @@ export interface MonitoringNestedStackProps extends NestedStackProps {
 	readonly vpc: ec2.IVpc
 	readonly vpcNetworking: Networking
     readonly openSearchDomain: opensearchservice.IDomain
-    readonly redisCluster: elasticache.CfnCacheCluster
+    readonly memoryDBCluster: memorydb.CfnCluster
     readonly internalUserPoolDomain: cognito.IUserPoolDomain
 }
 
@@ -37,7 +37,7 @@ export class MonitoringNestedStack extends NestedStack {
 				securityGroups,
 			},
 			openSearchDomain,
-			redisCluster,
+			memoryDBCluster,
 			internalUserPoolDomain,
 		} = props
 
@@ -47,7 +47,7 @@ export class MonitoringNestedStack extends NestedStack {
 			vpc,
 			securityGroup: securityGroups.dmz,
 			esEndpoint: openSearchDomain.domainEndpoint,
-			redisEndpoint: redisCluster.attrRedisEndpointAddress,
+			memoryDBEndpoint: memoryDBCluster.attrClusterEndpointAddress,
 			cognitoEndpoint: `${internalUserPoolDomain.domainName}.auth.${region}.amazoncognito.com`,
 		})
 	}

--- a/prototype/infra/lib/stack/nested/OrderOrchestrationStack/index.ts
+++ b/prototype/infra/lib/stack/nested/OrderOrchestrationStack/index.ts
@@ -16,7 +16,7 @@
  *********************************************************************************************************************/
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { Construct } from 'constructs'
-import { NestedStack, NestedStackProps, aws_dynamodb as ddb, aws_events as events, aws_ec2 as ec2, aws_lambda as lambda, aws_elasticache as elasticache } from 'aws-cdk-lib'
+import { NestedStack, NestedStackProps, aws_dynamodb as ddb, aws_events as events, aws_ec2 as ec2, aws_lambda as lambda, aws_memorydb as memorydb } from 'aws-cdk-lib'
 import * as api from '@aws-play/cdk-apigateway'
 import * as net from '@prototype/networking'
 import { OrderManagerStack } from '@prototype/order-manager'
@@ -30,7 +30,7 @@ export interface OrderOrchestrationStackProps extends NestedStackProps {
 	readonly vpc: ec2.IVpc
 	readonly vpcNetworking: net.Networking
 	readonly lambdaLayers: { [key: string]: lambda.ILayerVersion, }
-	readonly redisCluster: elasticache.CfnCacheCluster
+	readonly memoryDBCluster: memorydb.CfnCluster
 	readonly orderManagerSettings: { [key: string]: string | number | boolean, }
 }
 
@@ -48,7 +48,7 @@ export class OrderOrchestrationStack extends NestedStack {
 			vpcNetworking,
 			vpc,
 			lambdaLayers,
-			redisCluster,
+			memoryDBCluster,
 			orderManagerSettings,
 			demographicAreaProviderEngineSettings,
 		} = props
@@ -61,7 +61,7 @@ export class OrderOrchestrationStack extends NestedStack {
 			vpcNetworking,
 			privateVpc: vpc,
 			lambdaLayers,
-			redisCluster,
+			memoryDBCluster,
 			orderManagerSettings,
 			demographicAreaProviderEngineSettings,
 		})

--- a/prototype/infra/lib/stack/nested/ProviderStack/index.ts
+++ b/prototype/infra/lib/stack/nested/ProviderStack/index.ts
@@ -15,7 +15,7 @@
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
 import { Construct } from 'constructs'
-import { NestedStack, NestedStackProps, aws_lambda as lambda, aws_events as events, aws_ecs as ecs, aws_dynamodb as ddb, aws_elasticloadbalancingv2 as elb, aws_elasticache as elasticache, aws_ec2 as ec2 } from 'aws-cdk-lib'
+import { NestedStack, NestedStackProps, aws_lambda as lambda, aws_events as events, aws_ecs as ecs, aws_dynamodb as ddb, aws_elasticloadbalancingv2 as elb, aws_memorydb as memorydb, aws_ec2 as ec2 } from 'aws-cdk-lib'
 import { Networking } from '@prototype/networking'
 import { ExamplePollingProvider, ExampleWebhookProvider, InstantDeliveryProvider } from '@prototype/provider-impl'
 import { DispatchEngineOrchestrator, DriverEventHandler } from '@prototype/instant-delivery-provider'
@@ -29,7 +29,7 @@ export interface ProviderStackProps extends NestedStackProps {
 	readonly instantDeliveryProviderOrders: ddb.ITable
 	readonly instantDeliveryProviderLocks: ddb.ITable
 	readonly lambdaLayers: { [key: string]: lambda.ILayerVersion, }
-	readonly redisCluster: elasticache.CfnCacheCluster
+	readonly memoryDBCluster: memorydb.CfnCluster
 	readonly pollingProviderSettings: { [key: string]: string | number, }
 	readonly webhookProviderSettings: { [key: string]: string | number, }
 	readonly instantDeliveryProviderSettings: { [key: string]: string | number | boolean, }
@@ -66,7 +66,7 @@ export class ProviderStack extends NestedStack {
 			webhookProviderSettings,
 			externalProviderConfig,
 			instantDeliveryProviderSettings,
-			redisCluster,
+			memoryDBCluster,
 			instantDeliveryProviderLocks,
 			instantDeliveryProviderOrders,
 			instantDeliveryProviderOrdersStatusIndex,
@@ -96,7 +96,7 @@ export class ProviderStack extends NestedStack {
 			pollingProviderSettings,
 			externalProviderMockUrl: externalProviderConfig.MockPollingProvider.url,
 			externalProviderSecretName: externalProviderConfig.MockPollingProvider.apiKeySecretName,
-			redisCluster,
+			memoryDBCluster,
 			...baseParams,
 		})
 
@@ -104,7 +104,7 @@ export class ProviderStack extends NestedStack {
 			webhookProviderSettings,
 			externalProviderMockUrl: externalProviderConfig.MockWebhookProvider.url,
 			externalProviderSecretName: externalProviderConfig.MockWebhookProvider.apiKeySecretName,
-			redisCluster,
+			memoryDBCluster,
 			...baseParams,
 		})
 

--- a/prototype/infra/lib/stack/root/BackendStack/index.ts
+++ b/prototype/infra/lib/stack/root/BackendStack/index.ts
@@ -35,7 +35,7 @@ import * as path from 'path'
 export interface BackendStackProps extends StackProps {
 	readonly namespace: string
 	readonly persistent: PersistentBackendStack
-	readonly redisConfig: { [key: string]: string | number, }
+	readonly memoryDBConfig: { [key: string]: string | number, }
 	readonly kinesisConfig: { [key: string]: string | number | boolean, }
 	readonly deliveryAppConfig: { [key: string]: any, }
 	readonly pollingProviderSettings: { [key: string]: string | number, }
@@ -96,7 +96,7 @@ export class BackendStack extends Stack {
 				},
 				backendEcsCluster,
 			},
-			redisConfig,
+			memoryDBConfig,
 			kinesisConfig,
 			deliveryAppConfig,
 			pollingProviderSettings,
@@ -139,10 +139,10 @@ export class BackendStack extends Stack {
 			vpc,
 			userPool,
 			vpcNetworking,
-			redisCluster: liveDataCache.redisCluster,
+			memoryDBCluster: liveDataCache.memoryDBCluster,
 			openSearchDomain: liveDataCache.openSearchDomain,
 			driverDataIngestStream: streamingNestedStack.kinesisDataStreams.driverDataIngestStream,
-			redisConfig,
+			memoryDBConfig,
 			kinesisConfig,
 			env,
 		})
@@ -184,7 +184,7 @@ export class BackendStack extends Stack {
 			vpcNetworking,
 			eventBus: microServiceNestedStack.eventBus,
 			lambdaLayers: microServiceNestedStack.lambdaLayers,
-			redisCluster: liveDataCache.redisCluster,
+			memoryDBCluster: liveDataCache.memoryDBCluster,
 			instantDeliveryProviderOrders,
 			instantDeliveryProviderOrdersStatusIndex,
 			pollingProviderSettings,
@@ -207,7 +207,7 @@ export class BackendStack extends Stack {
 			vpc,
 			vpcNetworking,
 			lambdaLayers: microServiceNestedStack.lambdaLayers,
-			redisCluster: liveDataCache.redisCluster,
+			memoryDBCluster: liveDataCache.memoryDBCluster,
 			orderManagerSettings,
 			providerApiUrls: {
 				InstantDeliveryProvider: providerNestedStack.instantDeliveryWebhookProvider.apiGwInstance,

--- a/prototype/infra/lib/stack/root/DebugStack/index.ts
+++ b/prototype/infra/lib/stack/root/DebugStack/index.ts
@@ -55,7 +55,7 @@ export class DebugStack extends Stack {
 			vpc,
 			vpcNetworking,
 			openSearchDomain: liveDataCache.openSearchDomain,
-			redisCluster: liveDataCache.redisCluster,
+			memoryDBCluster: liveDataCache.memoryDBCluster,
 			internalUserPoolDomain,
 		})
 	}

--- a/prototype/infra/lib/stack/root/PersistentBackendStack/index.ts
+++ b/prototype/infra/lib/stack/root/PersistentBackendStack/index.ts
@@ -29,7 +29,7 @@ export interface PersistentBackendStackProps extends StackProps {
 
 	readonly vpcNetworkConfig: { [key: string]: [{ cidr: string, port: number, }], }
 	readonly openSearchConfig: { [key: string]: string | number, }
-	readonly redisConfig: { [key: string]: string | number, }
+	readonly memoryDBConfig: { [key: string]: string | number, }
 }
 
 /**
@@ -53,7 +53,7 @@ export class PersistentBackendStack extends Stack {
 
 		const {
 			namespace, administratorEmail, administratorName,
-			vpcNetworkConfig, openSearchConfig, redisConfig,
+			vpcNetworkConfig, openSearchConfig, memoryDBConfig,
 		} = props
 
 		setNamespace(this, namespace)
@@ -96,7 +96,7 @@ export class PersistentBackendStack extends Stack {
 			adminRole: internalIdentityStack.adminRole,
 			vpcNetworkConfig,
 			openSearchConfig,
-			redisConfig,
+			memoryDBConfig,
 		})
 
 		this.vpcPersistent = vpcPersistent

--- a/prototype/infra/lib/stack/root/SimulatorMainStack/index.ts
+++ b/prototype/infra/lib/stack/root/SimulatorMainStack/index.ts
@@ -65,7 +65,7 @@ export class SimulatorMainStack extends Stack {
 				backendBaseNestedStack: {
 					vpcNetworking,
 					liveDataCache: {
-						redisCluster,
+						memoryDBCluster,
 					},
 				},
 			},
@@ -165,7 +165,7 @@ export class SimulatorMainStack extends Stack {
 
 			lambdaLayers: lambdaLayerRefs,
 			privateVpc: vpc,
-			redisCluster,
+			memoryDBCluster,
 			vpcNetworking,
 
 			orderTable,

--- a/reports/cfn-nag-report.json
+++ b/reports/cfn-nag-report.json
@@ -533,15 +533,15 @@
           ],
           "line_numbers": [
             2700,
-            2831,
-            3028,
-            3195,
-            3491,
-            3756,
-            4023,
-            4261,
-            4425,
-            4616
+            2829,
+            3024,
+            3189,
+            3483,
+            3746,
+            4011,
+            4247,
+            4409,
+            4600
           ],
           "element_types": [
             "resource",
@@ -575,15 +575,15 @@
           ],
           "line_numbers": [
             2700,
-            2831,
-            3028,
-            3195,
-            3491,
-            3756,
-            4023,
-            4261,
-            4425,
-            4616
+            2829,
+            3024,
+            3189,
+            3483,
+            3746,
+            4011,
+            4247,
+            4409,
+            4600
           ],
           "element_types": [
             "resource",
@@ -623,8 +623,8 @@
             "LambdaFunctionsStackKinesisGeofencingConsumergeofencingDlq731D69E3"
           ],
           "line_numbers": [
-            3834,
-            4101
+            3822,
+            4087
           ],
           "element_types": [
             "resource",
@@ -648,7 +648,7 @@
             "OrderManagerStackOrderManagerHandlerServiceRoleDefaultPolicy8E9977C4"
           ],
           "line_numbers": [
-            613
+            611
           ],
           "element_types": [
             "resource"
@@ -666,8 +666,8 @@
           ],
           "line_numbers": [
             98,
-            293,
-            657
+            291,
+            655
           ],
           "element_types": [
             "resource",
@@ -684,7 +684,7 @@
             "OrderManagerStackProviderRuleEngineACDAE3AD"
           ],
           "line_numbers": [
-            293
+            291
           ],
           "element_types": [
             "resource"
@@ -702,8 +702,8 @@
           ],
           "line_numbers": [
             98,
-            293,
-            657
+            291,
+            655
           ],
           "element_types": [
             "resource",
@@ -741,20 +741,20 @@
             "InstantDeliveryProviderProviderApiGwInstanceInstantDeliveryProvidercallbackPOSTF8164DF5"
           ],
           "line_numbers": [
-            816,
-            966,
-            1191,
-            1416,
-            2691,
-            2841,
-            3066,
-            3291,
-            3459,
-            4695,
-            4845,
-            5070,
-            5295,
-            5463
+            810,
+            960,
+            1185,
+            1410,
+            2675,
+            2825,
+            3050,
+            3275,
+            3443,
+            4671,
+            4821,
+            5046,
+            5271,
+            5439
           ],
           "element_types": [
             "resource",
@@ -784,9 +784,9 @@
             "InstantDeliveryProviderProviderApiGwInstanceInstantDeliveryProviderDeploymentStageprod7F1AA99C"
           ],
           "line_numbers": [
-            753,
-            2628,
-            4632
+            747,
+            2612,
+            4608
           ],
           "element_types": [
             "resource",
@@ -803,7 +803,7 @@
             "GraphhopperSetupGraphhopperALB4E50D909"
           ],
           "line_numbers": [
-            5788
+            5764
           ],
           "element_types": [
             "resource"
@@ -818,7 +818,7 @@
             "GraphhopperSetupGraphhopperALBGHListenerB51A0073"
           ],
           "line_numbers": [
-            5821
+            5797
           ],
           "element_types": [
             "resource"
@@ -830,14 +830,14 @@
           "type": "WARN",
           "message": "IAM policy should not allow * resource",
           "logical_resource_ids": [
-            "ExampleWebhookProviderWebhookProviderLambdaConfigurationResourcekzi13qp8CustomResourcePolicy744B9E15",
+            "ExampleWebhookProviderWebhookProviderLambdaConfigurationResourcekzias8trCustomResourcePolicyD001ECB3",
             "GraphhopperSetupGraphhopperTaskDefExecutionRoleDefaultPolicy2E9329C0",
             "DispatchEngineOrchestratorOrchestratorHelperLambdaServiceRoleDefaultPolicy4DC37029"
           ],
           "line_numbers": [
-            3554,
-            5674,
-            5922
+            3538,
+            5650,
+            5898
           ],
           "element_types": [
             "resource",
@@ -854,7 +854,7 @@
             "DriverDataIngestStreamIdB09121CE"
           ],
           "line_numbers": [
-            3777
+            3753
           ],
           "element_types": [
             "resource"
@@ -887,23 +887,23 @@
           ],
           "line_numbers": [
             104,
-            302,
-            558,
-            1637,
-            1841,
-            2037,
-            2235,
-            2433,
-            3750,
-            3887,
-            4077,
-            4261,
-            4445,
-            6003,
-            6490,
-            6672,
-            6854,
-            6992
+            300,
+            554,
+            1631,
+            1833,
+            2027,
+            2223,
+            2419,
+            3726,
+            3863,
+            4053,
+            4237,
+            4421,
+            5979,
+            6466,
+            6648,
+            6830,
+            6968
           ],
           "element_types": [
             "resource",
@@ -939,11 +939,11 @@
             "DriverEventHandlerSubMinuteExecutionStepFunctionSubMinuteExecutionHelperB9BE06B1"
           ],
           "line_numbers": [
-            3750,
-            6490,
-            6672,
-            6854,
-            6992
+            3726,
+            6466,
+            6648,
+            6830,
+            6968
           ],
           "element_types": [
             "resource",
@@ -980,23 +980,23 @@
           ],
           "line_numbers": [
             104,
-            302,
-            558,
-            1637,
-            1841,
-            2037,
-            2235,
-            2433,
-            3750,
-            3887,
-            4077,
-            4261,
-            4445,
-            6003,
-            6490,
-            6672,
-            6854,
-            6992
+            300,
+            554,
+            1631,
+            1833,
+            2027,
+            2223,
+            2419,
+            3726,
+            3863,
+            4053,
+            4237,
+            4421,
+            5979,
+            6466,
+            6648,
+            6830,
+            6968
           ],
           "element_types": [
             "resource",
@@ -1028,7 +1028,7 @@
             "GraphhopperSetupGraphhopperTaskDefgraphhopperindonesiaLogGroup5BC3A5AC"
           ],
           "line_numbers": [
-            5646
+            5622
           ],
           "element_types": [
             "resource"
@@ -1043,7 +1043,7 @@
             "GraphhopperSetupGraphhopperTaskDefgraphhopperindonesiaLogGroup5BC3A5AC"
           ],
           "line_numbers": [
-            5646
+            5622
           ],
           "element_types": [
             "resource"
@@ -1062,11 +1062,11 @@
             "DriverDataIngestStreamIdB09121CE"
           ],
           "line_numbers": [
-            1456,
-            3499,
-            5503,
-            5788,
-            3777
+            1450,
+            3483,
+            5479,
+            5764,
+            3753
           ],
           "element_types": [
             "resource",
@@ -1087,9 +1087,9 @@
             "DispatchEngineOrchestratorOrderIngestKinesisConsumerinstantdeliveryproviderDlqAF169715"
           ],
           "line_numbers": [
-            400,
-            412,
-            6563
+            396,
+            408,
+            6539
           ],
           "element_types": [
             "resource",
@@ -1253,7 +1253,7 @@
             "AWS679f53fac002430cb0da5b7982bd22872D164C4C"
           ],
           "line_numbers": [
-            533
+            542
           ],
           "element_types": [
             "resource"
@@ -1268,7 +1268,7 @@
             "AWS679f53fac002430cb0da5b7982bd22872D164C4C"
           ],
           "line_numbers": [
-            533
+            542
           ],
           "element_types": [
             "resource"
@@ -1283,7 +1283,7 @@
             "AWS679f53fac002430cb0da5b7982bd22872D164C4C"
           ],
           "line_numbers": [
-            533
+            542
           ],
           "element_types": [
             "resource"
@@ -2003,17 +2003,17 @@
             "SimulatorManagerOriginSimulatorLambdaOriginEventHandlerServiceRoleDefaultPolicy70005689",
             "SimulatorManagerDestinationSimulatorLambdaDestinationGeneratorStepFunctionDestinationGeneratorHelperServiceRoleDefaultPolicy26A5D211",
             "SimulatorManagerDestinationSimulatorLambdaServiceRoleDefaultPolicyEC8238D5",
-            "UpdateLambdaConfigurationkzi13qysCustomResourcePolicyA7C26DB4"
+            "UpdateLambdaConfigurationkzias90pCustomResourcePolicy3337A8CE"
           ],
           "line_numbers": [
             5,
             5564,
             5992,
             6899,
-            7338,
-            7519,
-            8413,
-            9464
+            7334,
+            7515,
+            8409,
+            9456
           ],
           "element_types": [
             "resource",
@@ -2062,16 +2062,16 @@
             6400,
             6687,
             7017,
-            7195,
-            7379,
-            7619,
-            7926,
-            8213,
-            8517,
-            8660,
-            8839,
-            9108,
-            9319
+            7193,
+            7375,
+            7615,
+            7922,
+            8209,
+            8513,
+            8656,
+            8833,
+            9102,
+            9311
           ],
           "element_types": [
             "resource",
@@ -2126,13 +2126,13 @@
             6092,
             6400,
             6687,
-            7379,
-            7619,
-            7926,
-            8213,
-            8517,
-            8839,
-            9319
+            7375,
+            7615,
+            7922,
+            8209,
+            8513,
+            8833,
+            9311
           ],
           "element_types": [
             "resource",
@@ -2188,16 +2188,16 @@
             6400,
             6687,
             7017,
-            7195,
-            7379,
-            7619,
-            7926,
-            8213,
-            8517,
-            8660,
-            8839,
-            9108,
-            9319
+            7193,
+            7375,
+            7615,
+            7922,
+            8209,
+            8513,
+            8656,
+            8833,
+            9102,
+            9311
           ],
           "element_types": [
             "resource",
@@ -2238,9 +2238,9 @@
             5992,
             6314,
             6899,
-            7519,
-            7840,
-            8413
+            7515,
+            7836,
+            8409
           ],
           "element_types": [
             "resource",


### PR DESCRIPTION
*Issue #, if available:* #4

*Description of changes:*
* changing RedisCluster to MemoryDBCluster #4
* `redisClient` in lambdas won't be changed as this is fully compatible with redis6

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
