### PR TITLE
feat(sim): add support for multiple orders per driver

### DIFF
--- a/prototype/simulator/container/src/driver/commands/newOrder.js
+++ b/prototype/simulator/container/src/driver/commands/newOrder.js
@@ -21,20 +21,19 @@ const execute = async (payload) => {
 	logger.info('Executing command: newOrder')
 	logger.info('Payload', JSON.stringify(payload, null, 2))
 
-	const { orderId, destination, origin, routing } = payload
-	const currentState = state.getState()
-	const current = currentState.status
+	const { segments } = payload
+	const currentState = state.getStateRaw()
+	const current = currentState.assignmentStatus
 
-	if (current === state.STATUSES.IDLE) {
-		state.setState('orderId', orderId)
-		state.setState('destination', destination)
-		state.setState('origin', origin)
-		state.setState('routing', routing)
+	if (current === state.ASSIGNMENT_STATUS.IDLE) {
+		state.setState('segments', segments)
 		state.setState('status', state.STATUSES.ACCEPTED)
+		state.setState('assignmentStatus', state.ASSIGNMENT_STATUS.IN_PROGRESS)
 		state.setState('updates', currentState.updatesConfig.activeState)
 	} else {
 		state.setState('status', state.STATUSES.REJECTED)
 		state.setState('updates', currentState.updatesConfig.passiveState)
+		state.setState('assignmentStatus', state.ASSIGNMENT_STATUS.IDLE)
 	}
 }
 

--- a/prototype/simulator/container/src/driver/data/index.js
+++ b/prototype/simulator/container/src/driver/data/index.js
@@ -21,96 +21,82 @@ const helper = require('../../common/helper')
 
 let startingPosition
 let currentPosition
-let originPath
-let restProgress = 0
-let destinationPath
-let custProgress = 0
+let currentSegment
+let currentProgress
+let currentPath
+
+const getIdlePosition = (lat, long, radius) => {
+	if (!startingPosition) {
+		logger.info('Generating starting point...')
+		startingPosition = helper.generateRandomPoint(lat, long, radius)
+
+		return [startingPosition.latitude, startingPosition.longitude, startingPosition.elevation]
+	}
+
+	const { latitude, longitude } = startingPosition
+	// after the first initialization move the driver around the starting position
+	// within 100 meters to simulate motion
+	currentPosition = helper.generateRandomPoint(latitude, longitude, 100)
+
+	return [currentPosition.latitude, currentPosition.longitude, currentPosition.elevation]
+}
+
+const getSegmentLocations = (lat, long, radius, status, segments) => {
+	if (currentSegment >= segments.length) {
+		logger.info('Played all segments for assigment.')
+		state.setState('assignmentStatus', state.ASSIGNMENT_STATUS.IDLE)
+
+		return getIdlePosition(lat, long, radius)
+	}
+
+	const { orderId, from, to, segmentType, route } = segments[currentSegment]
+
+	state.setState('orderId', orderId)
+
+	if (!currentPath) {
+		currentPath = polyline.decode(route.points)
+
+		logger.info('Following path on: ', JSON.stringify(currentPath))
+	}
+	const [_lat, _long] = currentPath[currentProgress]
+
+	if (currentProgress < currentPath.length - 1) {
+		currentProgress++
+
+		return [_lat, _long, 0]
+	} else {
+		if (segmentType === 'TO_ORIGIN' && status === state.STATUSES.PICKING_UP_GOODS) {
+			logger.info('Arrived at origin. Order: ', orderId)
+
+			state.setState('status', state.STATUSES.ARRIVED_AT_ORIGIN)
+		}
+
+		if (segmentType === 'TO_DESTINATION' && status === state.STATUSES.DELIVERING) {
+			logger.info('Arrived at destination. Order: ', orderId)
+
+			state.setState('status', state.STATUSES.ARRIVED_AT_DESTINATION)
+		}
+
+		currentPath = null
+		currentProgress = 0
+		currentSegment++
+
+		return getSegmentLocations(lat, long, status, segments)
+	}
+}
 
 const getCoordinates = (lat, long, radius, status) => {
-	switch (status) {
-		case state.STATUSES.PICKING_UP_GOODS:
-		case state.STATUSES.ARRIVED_AT_ORIGIN: {
-			const toorigin = state.getState().routing
+	if (state.getState().assignmentStatus === state.ASSIGNMENT_STATUS.IDLE) {
+		currentPath = null
+		currentProgress = 0
+		currentSegment = 0
 
-			if (toorigin.length > 0) {
-				if (!originPath) {
-					const pathPolyline = toorigin[0].pathPolyline
-					originPath = polyline.decode(pathPolyline)
+		state.setState('segments', state.DEFAULT_STATE.segments)
 
-					logger.info('origin path')
-					logger.info(originPath)
-				}
-
-				const [_lat, _long] = originPath[restProgress]
-
-				if (restProgress === originPath.length - 1) {
-					if (status === state.STATUSES.PICKING_UP_GOODS) {
-						state.setState('status', state.STATUSES.ARRIVED_AT_ORIGIN)
-					}
-				} else {
-					restProgress++
-				}
-
-				return [_lat, _long, 0]
-			}
-
-			return [lat, long, 0]
-		}
-		case state.STATUSES.DELIVERING:
-		case state.STATUSES.ARRIVED_AT_DESTINATION:
-		case state.STATUSES.DELIVERED: {
-			const todestination = state.getState().routing
-
-			if (todestination.length > 1) {
-				if (!destinationPath) {
-					const pathPolyline = todestination[1].pathPolyline
-					destinationPath = polyline.decode(pathPolyline)
-
-					logger.info('destination path')
-					logger.info(destinationPath)
-				}
-
-				const [_lat, _long] = destinationPath[custProgress]
-
-				if (custProgress === destinationPath.length - 1) {
-					if (status === state.STATUSES.DELIVERING) {
-						state.setState('status', state.STATUSES.ARRIVED_AT_DESTINATION)
-					}
-				} else {
-					custProgress++
-				}
-
-				return [_lat, _long, 0]
-			}
-
-			return [lat, long, 0]
-		}
-		case state.STATUSES.IDLE:
-		case state.STATUSES.ACCEPTED:
-		default: {
-			destinationPath = null
-			originPath = null
-			custProgress = 0
-			restProgress = 0
-
-			state.setState('routing', state.DEFAULT_STATE.routing)
-			state.setState('destination', state.DEFAULT_STATE.destination)
-			state.setState('origin', state.DEFAULT_STATE.origin)
-
-			if (!startingPosition) {
-				startingPosition = helper.generateRandomPoint(lat, long, radius)
-
-				return [startingPosition.latitude, startingPosition.longitude, startingPosition.elevation]
-			}
-
-			const { latitude, longitude } = startingPosition
-			// after the first initialization move the driver around the starting position
-			// within 100 meters to simulate motion
-			currentPosition = helper.generateRandomPoint(latitude, longitude, 100)
-
-			return [currentPosition.latitude, currentPosition.longitude, currentPosition.elevation]
-		}
+		return getIdlePosition(lat, long, radius)
 	}
+
+	return getSegmentLocations(lat, long, radius, status, state.getState().segments)
 }
 
 /// range not used anymore at this point, due to wrong random point generation

--- a/prototype/simulator/container/src/driver/state/index.js
+++ b/prototype/simulator/container/src/driver/state/index.js
@@ -26,18 +26,16 @@ const STATUSES = {
 	DELIVERED: 'DELIVERED',
 }
 
+const ASSIGNMENT_STATUS = {
+	IDLE: 'IDLE',
+	IN_PROGRESS: 'IN_PROGRESS',
+}
+
 const state = {
+	assignmentStatus: 'IDLE',
 	status: 'IDLE',
 	orderId: '',
-	routing: [],
-	origin: {
-		lat: '',
-		long: '',
-	},
-	destination: {
-		lat: '',
-		long: '',
-	},
+	segments: [],
 	updatesConfig: {
 		passiveState: {
 			captureFrequency: 4,
@@ -108,7 +106,7 @@ const setStateChangeHandler = (prop, fn) => {
 }
 
 const generateChangeStatusMessage = (driverId, driverIdentity) => {
-	const { status, orderId } = state
+	const { status } = state
 	const baseMessage = {
 		type: 'STATUS_CHANGE',
 		driverId,
@@ -118,7 +116,7 @@ const generateChangeStatusMessage = (driverId, driverIdentity) => {
 	}
 
 	if (status !== STATUSES.IDLE) {
-		baseMessage.orderId = orderId
+		baseMessage.orderId = state.orderId
 	}
 
 	return baseMessage
@@ -132,4 +130,5 @@ module.exports = {
 	generateChangeStatusMessage,
 	STATUSES,
 	DEFAULT_STATE: state,
+	ASSIGNMENT_STATUS,
 }


### PR DESCRIPTION
*Issue #, if available:* closes #14

*Description of changes:*

- update the simulator to be able to handle multiple orders at the same time

[break]: this PR uses the latest payload structure as per #51 and requires refactoring on the instant delivery provider to change the structure of the messages going to the simulator


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
