### PR TITLE
feat(sim): add ability to replay remote event file

### DIFF
--- a/packages/@prototype/simulator/src/SimulatorManagerStack/DestinationSimulatorLambda/@lambda/src/commands/startSimulator.js
+++ b/packages/@prototype/simulator/src/SimulatorManagerStack/DestinationSimulatorLambda/@lambda/src/commands/startSimulator.js
@@ -25,7 +25,7 @@ const execute = async (input) => {
 	logger.info('Starting the simulation')
 
 	try {
-		const { orderRate, orderInterval, rejectionRate } = input
+		const { orderRate, orderInterval, rejectionRate, eventsFilePath } = input
 		const data = await ddb.scan(config.destinationStatsTable)
 		const stats = data.Items
 		const simulationId = uuidv4()
@@ -59,6 +59,7 @@ const execute = async (input) => {
 			orderRate,
 			orderInterval,
 			rejectionRate,
+			eventsFilePath,
 		})
 
 		const res = await step.startExecution({

--- a/packages/@prototype/simulator/src/SimulatorManagerStack/DestinationSimulatorLambda/DestinationStarterStepFunction/@lambda/src/commands/startSimulator.js
+++ b/packages/@prototype/simulator/src/SimulatorManagerStack/DestinationSimulatorLambda/DestinationStarterStepFunction/@lambda/src/commands/startSimulator.js
@@ -19,7 +19,7 @@ const ecs = require('../lib/ecs')
 const ddb = require('../lib/dynamoDB')
 const config = require('../config')
 
-const runTask = async (executionId, orderRate, orderInterval, rejectionRate) => {
+const runTask = async (executionId, orderRate, orderInterval, rejectionRate, eventsFilePath) => {
 	try {
 		const res = await ecs.runTask(
 			1,
@@ -28,6 +28,7 @@ const runTask = async (executionId, orderRate, orderInterval, rejectionRate) => 
 			orderRate,
 			orderInterval,
 			rejectionRate,
+			eventsFilePath,
 		)
 
 		const { failures, tasks } = res
@@ -65,6 +66,7 @@ const execute = async (payload) => {
 		Item.orderRate,
 		Item.orderInterval,
 		Item.rejectionRate,
+		Item.eventsFilePath,
 	)
 	const { tasks, failures } = res
 

--- a/packages/@prototype/simulator/src/SimulatorManagerStack/DestinationSimulatorLambda/DestinationStarterStepFunction/@lambda/src/config/index.js
+++ b/packages/@prototype/simulator/src/SimulatorManagerStack/DestinationSimulatorLambda/DestinationStarterStepFunction/@lambda/src/config/index.js
@@ -24,4 +24,5 @@ module.exports = {
 	securityGroup: process.env.SECURITY_GROUP,
 	containerName: process.env.CONTAINER_NAME,
 	simulatorApi: process.env.SIMULATOR_API,
+	simulatorConfigBucket: process.env.SIMULATOR_CONFIG_BUCKET,
 }

--- a/packages/@prototype/simulator/src/SimulatorManagerStack/DestinationSimulatorLambda/DestinationStarterStepFunction/@lambda/src/lib/ecs.js
+++ b/packages/@prototype/simulator/src/SimulatorManagerStack/DestinationSimulatorLambda/DestinationStarterStepFunction/@lambda/src/lib/ecs.js
@@ -26,6 +26,7 @@ const runTask = (
 	orderRate,
 	orderInterval,
 	rejectionRate,
+	eventsFilePath,
 ) => {
 	console.debug(`Starting ECS tasks, count: ${cnt}, num of processes per container: ${executionId}`)
 
@@ -54,6 +55,8 @@ const runTask = (
 						{ name: 'ORDER_INTERVAL', value: `${orderInterval}` },
 						{ name: 'REJECTION_RATE', value: `${rejectionRate}` },
 						{ name: 'SIMULATOR_API', value: `${config.simulatorApi}` },
+						{ name: 'SIMULATOR_CONFIG_BUCKET', value: `${config.simulatorConfigBucket}` },
+						{ name: 'EVENTS_FILE_PATH', value: `${eventsFilePath}` },
 						// TODO: change in prod
 						{ name: 'LOG_LEVEL', value: 'verbose' },
 					],

--- a/packages/@prototype/simulator/src/SimulatorManagerStack/DestinationSimulatorLambda/DestinationStarterStepFunction/index.ts
+++ b/packages/@prototype/simulator/src/SimulatorManagerStack/DestinationSimulatorLambda/DestinationStarterStepFunction/index.ts
@@ -15,7 +15,7 @@
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
 import { Construct } from 'constructs'
-import { Duration, aws_iam as iam, aws_dynamodb as ddb, aws_ec2 as ec2, aws_ecs as ecs, aws_lambda as lambda, aws_stepfunctions as stepfunctions, aws_stepfunctions_tasks as tasks } from 'aws-cdk-lib'
+import { Duration, aws_iam as iam, aws_dynamodb as ddb, aws_ec2 as ec2, aws_ecs as ecs, aws_lambda as lambda, aws_stepfunctions as stepfunctions, aws_stepfunctions_tasks as tasks, aws_s3 as s3 } from 'aws-cdk-lib'
 import { DeclaredLambdaFunction } from '@aws-play/cdk-lambda'
 import { namespaced } from '@aws-play/cdk-core'
 import { updateDDBTablePolicyStatement, readDDBTablePolicyStatement } from '@prototype/lambda-common'
@@ -29,6 +29,7 @@ export interface DestinationStarterStepFunctionProps {
 	readonly vpc: ec2.IVpc
 	readonly securityGroup: ec2.SecurityGroup
 	readonly cluster: ecs.Cluster
+	readonly simulatorConfigBucket: s3.Bucket
 }
 
 export class DestinationStarterStepFunction extends Construct {
@@ -48,6 +49,7 @@ export class DestinationStarterStepFunction extends Construct {
 			cluster,
 			vpc,
 			securityGroup,
+			simulatorConfigBucket,
 		} = props
 
 		this.environmentVariables = {
@@ -58,6 +60,7 @@ export class DestinationStarterStepFunction extends Construct {
 			SUBNETS: vpc.publicSubnets.map(q => q.subnetId).join(','),
 			SECURITY_GROUP: securityGroup.securityGroupId,
 			CONTAINER_NAME: destinationSimulatorContainer.containerDefinition.containerName,
+			SIMULATOR_CONFIG_BUCKET: simulatorConfigBucket.bucketName,
 		}
 		this.lambda = new lambda.Function(this, 'DestinationStarterHelper', {
 			functionName: namespaced(this, 'DestinationStarterHelper'),

--- a/packages/@prototype/simulator/src/SimulatorManagerStack/DestinationSimulatorLambda/index.ts
+++ b/packages/@prototype/simulator/src/SimulatorManagerStack/DestinationSimulatorLambda/index.ts
@@ -15,7 +15,7 @@
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
 import { Construct } from 'constructs'
-import { Duration, aws_dynamodb as ddb, aws_iam as iam, aws_ecs as ecs, aws_ec2 as ec2, aws_lambda as lambda, aws_cognito as cognito, aws_iot as iot, aws_stepfunctions as stepfunctions, aws_memorydb as memorydb, aws_events as events } from 'aws-cdk-lib'
+import { Duration, aws_dynamodb as ddb, aws_iam as iam, aws_ecs as ecs, aws_ec2 as ec2, aws_lambda as lambda, aws_cognito as cognito, aws_iot as iot, aws_stepfunctions as stepfunctions, aws_memorydb as memorydb, aws_events as events, aws_s3 as s3 } from 'aws-cdk-lib'
 import { Networking } from '@prototype/networking'
 import { DeclaredLambdaFunction } from '@aws-play/cdk-lambda'
 import { namespaced } from '@aws-play/cdk-core'
@@ -41,6 +41,7 @@ export interface DestinationSimulatorProps {
 	readonly vpc: ec2.IVpc
 	readonly securityGroup: ec2.SecurityGroup
 	readonly cluster: ecs.Cluster
+	readonly simulatorConfigBucket: s3.Bucket
 
 	readonly eventBus: events.EventBus
 	readonly privateVpc: ec2.IVpc
@@ -88,6 +89,7 @@ export class DestinationSimulatorLambda extends Construct {
 			lambdaLayers,
 			eventBus,
 			iotEndpointAddress,
+			simulatorConfigBucket,
 		} = props
 
 		const generator = new DestinationGeneratorStepFunction(this, 'DestinationGeneratorStepFunction', {
@@ -111,6 +113,7 @@ export class DestinationSimulatorLambda extends Construct {
 			cluster,
 			vpc,
 			securityGroup,
+			simulatorConfigBucket,
 		})
 
 		this.starterStepFunction = this.starter.stepFunction

--- a/prototype/simulator/container/package.json
+++ b/prototype/simulator/container/package.json
@@ -20,6 +20,7 @@
     "axios": "^0.25.0",
     "commander": "^7.2.0",
     "console-log-level": "^1.4.1",
+    "dayjs": "^1.10.7",
     "dotenv": "^8.2.0",
     "glob": "^7.1.6",
     "nanoid": "^3.2.0"

--- a/prototype/simulator/container/src/common/helper/index.js
+++ b/prototype/simulator/container/src/common/helper/index.js
@@ -18,7 +18,7 @@ const aws = require('../lib/aws-sdk')
 const userData = require('../lib/userData')
 const amplify = require('../lib/amplify')
 const cognito = require('../lib/cognito')
-const { loadRemoteConfig } = require('../lib/s3')
+const { loadRemoteFile } = require('../lib/s3')
 const logger = require('../utils/logger')
 const config = require('../config')
 
@@ -164,7 +164,7 @@ module.exports = {
 	refreshCredentials,
 	initialiseUser,
 	setupIdentity,
-	loadRemoteConfig,
+	loadRemoteFile,
 	terminateUser,
 	publishMessage,
 	generateRandomPoint,

--- a/prototype/simulator/container/src/common/lib/s3.js
+++ b/prototype/simulator/container/src/common/lib/s3.js
@@ -20,7 +20,7 @@ const logger = require('../utils/logger')
 
 const s3 = new aws.S3()
 
-const loadRemoteConfig = async (Bucket, Key) => {
+const loadRemoteFile = async (Bucket, Key) => {
 	const params = {
 		Bucket,
 		Key,
@@ -36,4 +36,4 @@ const loadRemoteConfig = async (Bucket, Key) => {
 	return remoteConfigContent.data
 }
 
-module.exports.loadRemoteConfig = loadRemoteConfig
+module.exports.loadRemoteFile = loadRemoteFile

--- a/prototype/simulator/container/src/destination/config/index.js
+++ b/prototype/simulator/container/src/destination/config/index.js
@@ -21,6 +21,8 @@ module.exports = {
 	destinationExecutionIdIndex: process.env.DESTINATION_EXECUTIONID_INDEX,
 	destinationStatusUpdateRule: process.env.DESTINATION_STATUS_UPDATE_RULE_NAME,
 	executionId: process.env.EXECUTION_ID,
+	simulatorConfigBucket: process.env.SIMULATOR_CONFIG_BUCKET,
+	eventsFilePath: process.env.EVENTS_FILE_PATH,
 	orderRate: parseInt(process.env.ORDER_RATE),
 	orderInterval: process.env.ORDER_INTERVAL,
 	rejectionRate: parseFloat(process.env.REJECTION_RATE),

--- a/prototype/simulator/container/src/destination/destination.js
+++ b/prototype/simulator/container/src/destination/destination.js
@@ -97,7 +97,7 @@ class Destination {
 
 		// start to send orders every
 		this.orderInterval = setInterval(async () => {
-			const nowInSeconds = dayjs().format('HHmmss')
+			const nowInSeconds = Number(dayjs().format('HHmmss'))
 
 			// if there are orders to send during this "second", will send them altogether
 			if (validOrders[nowInSeconds]) {

--- a/prototype/simulator/container/src/destination/helper/request.js
+++ b/prototype/simulator/container/src/destination/helper/request.js
@@ -43,10 +43,11 @@ const getRandomOrigin = async (area, jwt) => {
 	}
 }
 
-const createOrder = async (origin, destination, jwt) => {
+const createOrder = async (origin, destination, jwt, payload) => {
 	const res = await axios.default.post(`${config.simulatorApiEndpoint}/order`, {
 		origin,
 		destination,
+		payload,
 		quantity: 1,
 	}, {
 		headers: {

--- a/prototype/simulator/container/src/destination/index.js
+++ b/prototype/simulator/container/src/destination/index.js
@@ -25,6 +25,7 @@ class DestinationApp {
 			orderRate: config.orderRate || options.orderRate,
 			orderInterval: config.orderInterval || options.orderInterval,
 			rejectionRate: config.rejectionRate || options.rejectionRate,
+			eventsFilePath: config.eventsFilePath || options.eventsFilePath,
 		}
 		logger.debug('Starting the Destination App with params: ', JSON.stringify(params))
 
@@ -38,7 +39,8 @@ class DestinationApp {
 		const data = await ddb.query(this.config.destinationTable, this.config.destinationExecutionIdIndex, {
 			executionId: this.params.executionId,
 		})
-		const users = data.Items
+		// in case we replay an existing file we need just one destination object to perform the order submission
+		const users = this.params.eventsFilePath ? [data.Items[0]] : data.Items
 		const destinations = users.map(u => new Destination(this.config, this.params, u, this))
 		logger.log('Initialising destinations')
 

--- a/prototype/simulator/container/src/destinationApp.js
+++ b/prototype/simulator/container/src/destinationApp.js
@@ -31,6 +31,7 @@ program
 .option('-or, --order-rate <number orders>', 'Number of order to submit')
 .option('-oi, --order-interval <s/m/h>', 'Interval to use for order submission; hour (h), minute (m) or seconds (s)')
 .option('-rr, --rejection-rate <percentage>', 'Reject a subset of orders (in %)')
+.action('-ef, --events-file-path [configuration-file]', 'Replay a set of events in the order they appear in the configuration file')
 program.parse(process.argv)
 const options = program.opts();
 

--- a/prototype/simulator/container/src/driver/index.js
+++ b/prototype/simulator/container/src/driver/index.js
@@ -39,7 +39,7 @@ class DriverApp {
 
 	async init () {
 		const [identity, user] = await helper.setupIdentity(this.config.iotPolicyName, this.config.baseUsername)
-		const remoteConfig = await helper.loadRemoteConfig(this.config.updateConfigBucket, this.config.updateConfigPath)
+		const remoteConfig = await helper.loadRemoteFile(this.config.updateConfigBucket, this.config.updateConfigPath)
 
 		stateManager.setState('updatesConfig', remoteConfig, false)
 		stateManager.setState('updates', remoteConfig.passiveState, false)


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:*

This set of changes adds the ability to replay a remote configured file as source of events (eg. orders) in the simulator. The simulator still retain the option to generate events (orders) in case the configured file is not provided.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
