### PR TITLE
refactor(common): refactor common package to use generic construct names and namespaces

### DIFF
--- a/packages/@prototype/appconfig/package.json
+++ b/packages/@prototype/appconfig/package.json
@@ -23,7 +23,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@aws-play/cdk-core": "^0.0.0-alpha.14"
+    "@aws-play/cdk-core": "^0.0.0-alpha.14",
+    "@prototype/common": "^0.0.0-alpha.0"
   },
   "peerDependencies": {
     "aws-cdk-lib": "^2.10.0",

--- a/packages/@prototype/appconfig/src/AppConfigNestedStack/ConfigStorage/index.ts
+++ b/packages/@prototype/appconfig/src/AppConfigNestedStack/ConfigStorage/index.ts
@@ -17,7 +17,7 @@
 import { Construct } from 'constructs'
 import { namespacedBucket } from '@aws-play/cdk-core'
 import { aws_s3 as s3 } from 'aws-cdk-lib'
-import { HyperlocalBucket } from '@prototype/common'
+import { hyperlocal_s3 } from '@prototype/common'
 
 export class ConfigStorage extends Construct {
 	public readonly configBucket: s3.IBucket
@@ -25,7 +25,7 @@ export class ConfigStorage extends Construct {
 	constructor (scope: Construct, id: string) {
 		super(scope, id)
 
-		this.configBucket = new HyperlocalBucket(this, 'ConfigBucket', {
+		this.configBucket = new hyperlocal_s3.Bucket(this, 'ConfigBucket', {
 			bucketName: namespacedBucket(this, 'config'),
 			versioned: true,
 		})

--- a/packages/@prototype/common/src/constructs/DynamoDB/Table.ts
+++ b/packages/@prototype/common/src/constructs/DynamoDB/Table.ts
@@ -15,25 +15,14 @@
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
 import { Construct } from 'constructs'
-import { NestedStack, NestedStackProps, aws_dynamodb as ddb } from 'aws-cdk-lib'
-import { hyperlocal_ddb } from '@prototype/common'
-import { namespaced } from '@aws-play/cdk-core'
+import { aws_dynamodb as ddb } from 'aws-cdk-lib'
 
-type ExternalPollingDataStackProps = NestedStackProps
-
-export class ExternalPollingDataStack extends NestedStack {
-	public readonly externalOrderTable: ddb.Table
-
-	constructor (scope: Construct, id: string, props: ExternalPollingDataStackProps) {
-		super(scope, id)
-
-		this.externalOrderTable = new hyperlocal_ddb.Table(this, 'ExamplePollingOrders', {
-			tableName: namespaced(this, 'example-polling-orders'),
-			removalPolicy: props.removalPolicy,
-			partitionKey: {
-				name: 'ID',
-				type: ddb.AttributeType.STRING,
-			},
+export class Table extends ddb.Table {
+	constructor (scope: Construct, id: string, props: ddb.TableProps) {
+		super(scope, id, {
+			billingMode: ddb.BillingMode.PAY_PER_REQUEST,
+			encryption: ddb.TableEncryption.AWS_MANAGED,
+			...props,
 		})
 	}
 }

--- a/packages/@prototype/common/src/constructs/DynamoDB/index.ts
+++ b/packages/@prototype/common/src/constructs/DynamoDB/index.ts
@@ -14,15 +14,4 @@
  *  IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN                                          *
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
-import { Construct } from 'constructs'
-import { aws_dynamodb as ddb } from 'aws-cdk-lib'
-
-export class HyperlocalTable extends ddb.Table {
-	constructor (scope: Construct, id: string, props: ddb.TableProps) {
-		super(scope, id, {
-			billingMode: ddb.BillingMode.PAY_PER_REQUEST,
-			encryption: ddb.TableEncryption.AWS_MANAGED,
-			...props,
-		})
-	}
-}
+export * from './Table'

--- a/packages/@prototype/common/src/constructs/S3/Bucket.ts
+++ b/packages/@prototype/common/src/constructs/S3/Bucket.ts
@@ -17,7 +17,7 @@
 import { Construct } from 'constructs'
 import { aws_s3 as s3 } from 'aws-cdk-lib'
 
-export class HyperlocalBucket extends s3.Bucket {
+export class Bucket extends s3.Bucket {
 	constructor (scope: Construct, id: string, props: s3.BucketProps) {
 		super(scope, id, {
 			enforceSSL: true,

--- a/packages/@prototype/common/src/constructs/S3/index.ts
+++ b/packages/@prototype/common/src/constructs/S3/index.ts
@@ -14,26 +14,4 @@
  *  IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN                                          *
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
-import { Construct } from 'constructs'
-import { NestedStack, NestedStackProps, aws_dynamodb as ddb } from 'aws-cdk-lib'
-import { hyperlocal_ddb } from '@prototype/common'
-import { namespaced } from '@aws-play/cdk-core'
-
-type ExternalPollingDataStackProps = NestedStackProps
-
-export class ExternalPollingDataStack extends NestedStack {
-	public readonly externalOrderTable: ddb.Table
-
-	constructor (scope: Construct, id: string, props: ExternalPollingDataStackProps) {
-		super(scope, id)
-
-		this.externalOrderTable = new hyperlocal_ddb.Table(this, 'ExamplePollingOrders', {
-			tableName: namespaced(this, 'example-polling-orders'),
-			removalPolicy: props.removalPolicy,
-			partitionKey: {
-				name: 'ID',
-				type: ddb.AttributeType.STRING,
-			},
-		})
-	}
-}
+export * from './Bucket'

--- a/packages/@prototype/common/src/constructs/index.ts
+++ b/packages/@prototype/common/src/constructs/index.ts
@@ -15,5 +15,5 @@
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
 export * from './DefaultWaf'
-export * from './HyperlocalBucket'
-export * from './HyperlocalTable'
+export * as hyperlocal_s3 from './S3'
+export * as hyperlocal_ddb from './DynamoDB'

--- a/packages/@prototype/data-storage/package.json
+++ b/packages/@prototype/data-storage/package.json
@@ -23,7 +23,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@prototype/common": "0.0.0-alpha.0",
+    "@prototype/common": "^0.0.0-alpha.0",
     "@aws-play/cdk-core": "^0.0.0-alpha.14",
     "@aws-sdk/types": "^3.20.0",
     "@aws-sdk/util-dynamodb": "^3.21.0"

--- a/packages/@prototype/data-storage/src/DataStoragePersistent/index.ts
+++ b/packages/@prototype/data-storage/src/DataStoragePersistent/index.ts
@@ -17,7 +17,7 @@
 import { Construct } from 'constructs'
 import { NestedStack, NestedStackProps, aws_dynamodb as ddb, aws_s3 as s3 } from 'aws-cdk-lib'
 import { namespaced, namespacedBucket } from '@aws-play/cdk-core'
-import { HyperlocalTable, HyperlocalBucket } from '@prototype/common'
+import { hyperlocal_ddb, hyperlocal_s3 } from '@prototype/common'
 import { DatabaseSeeder } from './DatabaseSeeder'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -49,15 +49,15 @@ export class DataStoragePersistent extends NestedStack {
 	constructor (scope: Construct, id: string, props: DataStoragePersistentProps) {
 		super(scope, id, props)
 
-		this.dispatchEngineBucket = new HyperlocalBucket(this, 'DispatchEngineBucket', {
+		this.dispatchEngineBucket = new hyperlocal_s3.Bucket(this, 'DispatchEngineBucket', {
 			bucketName: namespacedBucket(this, 'dispatch-engine'),
 		})
 
-		this.driversTelemetryBucket = new HyperlocalBucket(this, 'DriversTelemetryBucket', {
+		this.driversTelemetryBucket = new hyperlocal_s3.Bucket(this, 'DriversTelemetryBucket', {
 			bucketName: namespacedBucket(this, 'drivers-telemetry'),
 		})
 
-		this.geoPolygonTable = new HyperlocalTable(this, 'GeoPolygonTable', {
+		this.geoPolygonTable = new hyperlocal_ddb.Table(this, 'GeoPolygonTable', {
 			tableName: namespaced(this, 'geoPolygon'),
 			removalPolicy: props.removalPolicy,
 			partitionKey: {
@@ -66,7 +66,7 @@ export class DataStoragePersistent extends NestedStack {
 			},
 		})
 
-		this.orderTable = new HyperlocalTable(this, 'OrderTable', {
+		this.orderTable = new hyperlocal_ddb.Table(this, 'OrderTable', {
 			tableName: namespaced(this, 'order'),
 			removalPolicy: props.removalPolicy,
 			partitionKey: {
@@ -75,7 +75,7 @@ export class DataStoragePersistent extends NestedStack {
 			},
 		})
 
-		const instantDeliveryProviderOrders = new HyperlocalTable(this, 'InstantDeliveryProviderOrders', {
+		const instantDeliveryProviderOrders = new hyperlocal_ddb.Table(this, 'InstantDeliveryProviderOrders', {
 			tableName: namespaced(this, 'instant-delivery-provider-orders'),
 			removalPolicy: props.removalPolicy,
 			partitionKey: {
@@ -100,7 +100,7 @@ export class DataStoragePersistent extends NestedStack {
 		this.instantDeliveryProviderOrdersStatusIndex = instantDeliveryProviderOrdersStatusIndex
 		this.instantDeliveryProviderOrders = instantDeliveryProviderOrders
 
-		this.demographicAreaDispatchSettings = new HyperlocalTable(this, 'DemographicAreaDispatchSettings', {
+		this.demographicAreaDispatchSettings = new hyperlocal_ddb.Table(this, 'DemographicAreaDispatchSettings', {
 			tableName: namespaced(this, 'demographic-area-dispatch-settings'),
 			removalPolicy: props.removalPolicy,
 			partitionKey: {
@@ -109,7 +109,7 @@ export class DataStoragePersistent extends NestedStack {
 			},
 		})
 
-		this.demographicAreaProviderEngineSettings = new HyperlocalTable(this, 'DemographicAreaProviderEngineSettings', {
+		this.demographicAreaProviderEngineSettings = new hyperlocal_ddb.Table(this, 'DemographicAreaProviderEngineSettings', {
 			tableName: namespaced(this, 'demographic-area-provider-engine-settings'),
 			removalPolicy: props.removalPolicy,
 			partitionKey: {
@@ -118,7 +118,7 @@ export class DataStoragePersistent extends NestedStack {
 			},
 		})
 
-		this.instantDeliveryProviderLocks = new HyperlocalTable(this, 'InstantDeliveryProviderLocks', {
+		this.instantDeliveryProviderLocks = new hyperlocal_ddb.Table(this, 'InstantDeliveryProviderLocks', {
 			tableName: namespaced(this, 'inteinstant-delivery-provider-locks'),
 			removalPolicy: props.removalPolicy,
 			partitionKey: {
@@ -133,7 +133,7 @@ export class DataStoragePersistent extends NestedStack {
 			geoPolygonTable: this.geoPolygonTable,
 		})
 
-		this.dispatcherAssignmentsTable = new HyperlocalTable(this, 'DispatcherAssignments', {
+		this.dispatcherAssignmentsTable = new hyperlocal_ddb.Table(this, 'DispatcherAssignments', {
 			tableName: namespaced(this, 'dispatcher-assignments'),
 			removalPolicy: props.removalPolicy,
 			partitionKey: {

--- a/packages/@prototype/dispatch-setup/package.json
+++ b/packages/@prototype/dispatch-setup/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@prototype/lambda-common": "0.0.0-alpha.0",
+    "@prototype/common": "^0.0.0-alpha.0",
     "mustache": "^4.2.0"
   },
   "devDependencies": {

--- a/packages/@prototype/external-provider-mock/package.json
+++ b/packages/@prototype/external-provider-mock/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@aws-play/cdk-core": "^0.0.0-alpha.14",
-    "@aws-play/cdk-lambda": "^0.0.0-alpha.1"
+    "@aws-play/cdk-lambda": "^0.0.0-alpha.1",
+    "@prototype/common": "^0.0.0-alpha.0"
   }
 }

--- a/packages/@prototype/external-provider-mock/src/ExternalWebhookProviderStack/DataStack/index.ts
+++ b/packages/@prototype/external-provider-mock/src/ExternalWebhookProviderStack/DataStack/index.ts
@@ -17,7 +17,7 @@
 import { Construct } from 'constructs'
 import { NestedStack, NestedStackProps, aws_dynamodb as ddb } from 'aws-cdk-lib'
 import { namespaced } from '@aws-play/cdk-core'
-import { HyperlocalTable } from '@prototype/common'
+import { hyperlocal_ddb } from '@prototype/common'
 
 type ExternalWebhookDataStackProps = NestedStackProps
 
@@ -29,7 +29,7 @@ export class ExternalWebhookDataStack extends NestedStack {
 	constructor (scope: Construct, id: string, props: ExternalWebhookDataStackProps) {
 		super(scope, id)
 
-		this.externalOrderTable = new HyperlocalTable(this, 'ExampleWebhookOrders', {
+		this.externalOrderTable = new hyperlocal_ddb.Table(this, 'ExampleWebhookOrders', {
 			tableName: namespaced(this, 'example-webhook-orders'),
 			removalPolicy: props.removalPolicy,
 			partitionKey: {

--- a/packages/@prototype/monitoring/package.json
+++ b/packages/@prototype/monitoring/package.json
@@ -23,7 +23,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@aws-play/cdk-core": "^0.0.0-alpha.14"
+    "@aws-play/cdk-core": "^0.0.0-alpha.14",
+    "@prototype/common": "^0.0.0-alpha.0"
   },
   "peerDependencies": {
     "aws-cdk-lib": "^2.10.0",

--- a/packages/@prototype/monitoring/src/Monitoring/index.ts
+++ b/packages/@prototype/monitoring/src/Monitoring/index.ts
@@ -19,7 +19,7 @@ import * as path from 'path'
 import { Construct } from 'constructs'
 import { aws_ec2 as ec2, aws_iam as iam, aws_s3 as s3, custom_resources as cr } from 'aws-cdk-lib'
 import { namespaced, namespacedBucket } from '@aws-play/cdk-core'
-import { HyperlocalBucket } from '@prototype/common'
+import { hyperlocal_s3 } from '@prototype/common'
 
 export interface MonitoringProps {
     readonly esEndpoint: string
@@ -38,7 +38,7 @@ export class Monitoring extends Construct {
 			securityGroup,
 		} = props
 
-		const debugInstanceBucket = new HyperlocalBucket(this, 'DebugInstanceBucket', {
+		const debugInstanceBucket = new hyperlocal_s3.Bucket(this, 'DebugInstanceBucket', {
 			bucketName: namespacedBucket(this, 'debug-instance-config'),
 		})
 

--- a/packages/@prototype/provider/package.json
+++ b/packages/@prototype/provider/package.json
@@ -25,7 +25,8 @@
   "dependencies": {
     "@aws-play/cdk-core": "^0.0.0-alpha.14",
     "@aws-play/cdk-apigateway": "0.0.0-alpha.4",
-    "@aws-play/cdk-lambda": "^0.0.0-alpha.1"
+    "@aws-play/cdk-lambda": "^0.0.0-alpha.1",
+    "@prototype/common": "^0.0.0-alpha.0"
   },
   "peerDependencies": {
     "aws-cdk-lib": "^2.10.0",

--- a/packages/@prototype/simulator/package.json
+++ b/packages/@prototype/simulator/package.json
@@ -26,6 +26,7 @@
     "@aws-play/cdk-core": "0.0.0-alpha.14",
     "@aws-play/cdk-apigateway": "^0.0.0-alpha.4",
     "@aws-play/cdk-lambda": "^0.0.0-alpha.1",
+    "@prototype/common": "^0.0.0-alpha.0",
     "@prototype/lambda-common": "^0.0.0-alpha.0",
     "cdk-iam-actions": "^1.0.0",
     "http-method-enum": "^1.0.0"

--- a/packages/@prototype/simulator/src/SimulatorDataStack/index.ts
+++ b/packages/@prototype/simulator/src/SimulatorDataStack/index.ts
@@ -17,7 +17,7 @@
 import { Construct } from 'constructs'
 import { NestedStack, NestedStackProps, aws_dynamodb as ddb } from 'aws-cdk-lib'
 import { namespaced } from '@aws-play/cdk-core'
-import { HyperlocalTable } from '@prototype/common'
+import { hyperlocal_ddb } from '@prototype/common'
 
 type SimulatorDataStackProps = NestedStackProps
 
@@ -51,7 +51,7 @@ export class SimulatorDataStack extends NestedStack {
 	constructor (scope: Construct, id: string, props: SimulatorDataStackProps) {
 		super(scope, id)
 
-		this.simulatorTable = new HyperlocalTable(this, 'SimulatorTable', {
+		this.simulatorTable = new hyperlocal_ddb.Table(this, 'SimulatorTable', {
 			tableName: namespaced(this, 'simulator'),
 			removalPolicy: props.removalPolicy,
 			partitionKey: {
@@ -60,7 +60,7 @@ export class SimulatorDataStack extends NestedStack {
 			},
 		})
 
-		this.eventTable = new HyperlocalTable(this, 'EventTable', {
+		this.eventTable = new hyperlocal_ddb.Table(this, 'EventTable', {
 			tableName: namespaced(this, 'event'),
 			removalPolicy: props.removalPolicy,
 			partitionKey: {
@@ -83,7 +83,7 @@ export class SimulatorDataStack extends NestedStack {
 			},
 		})
 
-		this.originTable = new HyperlocalTable(this, 'OriginTable', {
+		this.originTable = new hyperlocal_ddb.Table(this, 'OriginTable', {
 			tableName: namespaced(this, 'origin'),
 			removalPolicy: props.removalPolicy,
 			partitionKey: {
@@ -110,7 +110,7 @@ export class SimulatorDataStack extends NestedStack {
 			},
 		})
 
-		this.originStatsTable = new HyperlocalTable(this, 'OriginStatsTable', {
+		this.originStatsTable = new hyperlocal_ddb.Table(this, 'OriginStatsTable', {
 			tableName: namespaced(this, 'origin-stats'),
 			removalPolicy: props.removalPolicy,
 			partitionKey: {
@@ -119,7 +119,7 @@ export class SimulatorDataStack extends NestedStack {
 			},
 		})
 
-		this.originSimulationsTable = new HyperlocalTable(this, 'OriginSimulationsTable', {
+		this.originSimulationsTable = new hyperlocal_ddb.Table(this, 'OriginSimulationsTable', {
 			tableName: namespaced(this, 'origin-simulations'),
 			removalPolicy: props.removalPolicy,
 			partitionKey: {
@@ -128,7 +128,7 @@ export class SimulatorDataStack extends NestedStack {
 			},
 		})
 
-		this.destinationTable = new HyperlocalTable(this, 'DestinationTable', {
+		this.destinationTable = new hyperlocal_ddb.Table(this, 'DestinationTable', {
 			tableName: namespaced(this, 'destination'),
 			removalPolicy: props.removalPolicy,
 			partitionKey: {
@@ -155,7 +155,7 @@ export class SimulatorDataStack extends NestedStack {
 			},
 		})
 
-		this.destinationStatsTable = new HyperlocalTable(this, 'DestinationStatsTable', {
+		this.destinationStatsTable = new hyperlocal_ddb.Table(this, 'DestinationStatsTable', {
 			tableName: namespaced(this, 'destination-stats'),
 			removalPolicy: props.removalPolicy,
 			partitionKey: {
@@ -164,7 +164,7 @@ export class SimulatorDataStack extends NestedStack {
 			},
 		})
 
-		this.destinationSimulationsTable = new HyperlocalTable(this, 'DestinationSimulationsTable', {
+		this.destinationSimulationsTable = new hyperlocal_ddb.Table(this, 'DestinationSimulationsTable', {
 			tableName: namespaced(this, 'destination-simulations'),
 			removalPolicy: props.removalPolicy,
 			partitionKey: {

--- a/packages/@prototype/simulator/src/SimulatorManagerStack/index.ts
+++ b/packages/@prototype/simulator/src/SimulatorManagerStack/index.ts
@@ -29,7 +29,7 @@ import { StatisticsLambda } from './StatisticsLambda'
 import { SimulatorContainer } from '../ECSContainerStack/SimulatorContainer'
 import { DispatcherAssignmentQueryLambda } from './DispatcherAssignmentQueryLambda'
 import { namespacedBucket } from '@aws-play/cdk-core'
-import { HyperlocalBucket } from '@prototype/common'
+import { hyperlocal_s3 } from '@prototype/common'
 
 export interface SimulatorManagerStackProps {
 	readonly vpc: ec2.IVpc
@@ -129,7 +129,7 @@ export class SimulatorManagerStack extends Construct {
 			iotEndpointAddress,
 		} = props
 
-		const simulatorConfigBucket = new HyperlocalBucket(this, 'SimulatorConfig', {
+		const simulatorConfigBucket = new hyperlocal_s3.Bucket(this, 'SimulatorConfig', {
 			bucketName: namespacedBucket(this, 'simulator-config'),
 			versioned: true,
 		})


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:*

- refactor `HyperlocalBucket` and `HyperlocalTable` to use generic construct names (eg. `Table`, `Bucket`).
- add namespaces to distinguish them from CDK construct 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
