### PR TITLE
feat(infra): switch docker build to use linux/arm64 to benefit from Graviton2 

### DIFF
--- a/packages/@prototype/dispatch-setup/src/GraphhopperSetup/docker/Dockerfile
+++ b/packages/@prototype/dispatch-setup/src/GraphhopperSetup/docker/Dockerfile
@@ -1,6 +1,6 @@
 ##
 # Build stage for generating graphhopper cache
-FROM maven:3.6.3-jdk-11 as build
+FROM --platform=linux/arm64 maven:3.6.3-jdk-11 as build
 
 ARG MAPFILE_URL=set_MAPFILE_URL_env_var
 

--- a/packages/@prototype/simulator/src/ECSContainerStack/SimulatorContainer/index.ts
+++ b/packages/@prototype/simulator/src/ECSContainerStack/SimulatorContainer/index.ts
@@ -138,6 +138,10 @@ export class SimulatorContainer extends Construct {
 			compatibility: ecs.Compatibility.FARGATE,
 			cpu: `${cpu}`,
 			memoryMiB: `${memoryMiB}`,
+			runtimePlatform: {
+				cpuArchitecture: ecs.CpuArchitecture.ARM64,
+				operatingSystemFamily: ecs.OperatingSystemFamily.LINUX,
+			},
 		})
 
 		// containerDef

--- a/prototype/dispatch/order-dispatcher/src/main/docker/Dockerfile.jvm
+++ b/prototype/dispatch/order-dispatcher/src/main/docker/Dockerfile.jvm
@@ -1,5 +1,5 @@
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
+FROM --platform=linux/arm64 registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
 ARG JAVA_PACKAGE=java-11-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8

--- a/prototype/dispatch/order-dispatcher/src/main/docker/instant/sequential/Dockerfile
+++ b/prototype/dispatch/order-dispatcher/src/main/docker/instant/sequential/Dockerfile
@@ -1,6 +1,6 @@
 ##
 # Build stage for generating graphhopper cache
-FROM maven:3.6.3-jdk-11 as gh-build
+FROM --platform=linux/arm64 maven:3.6.3-jdk-11 as gh-build
 
 ARG MAPFILE_URL=set_MAPFILE_URL_env_var
 

--- a/prototype/scripts/graphhopper/Dockerfile
+++ b/prototype/scripts/graphhopper/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.6.3-jdk-11 as build
+FROM --platform=linux/arm64 maven:3.6.3-jdk-11 as build
 
 ARG MAPFILE_URL=set_MAPFILE_URL_env_var
 

--- a/prototype/simulator/container/Dockerfile
+++ b/prototype/simulator/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine3.14
+FROM --platform=linux/arm64 node:16-alpine3.14
 
 # Create app directory
 WORKDIR /usr/src/app


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:*

- update all docker files to make sure to use `--platform=linux/arm64` so that the build is compatible with the Graviton2 instances utilised in EC2/Fargate container tasks

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
