### PR TITLE
fix(infra): fix usage of memorydb port and add a workaround to avoid runtime errors

### DIFF
--- a/packages/@prototype/api-geotracking/src/ApiGeofencing/GeofencingService/index.ts
+++ b/packages/@prototype/api-geotracking/src/ApiGeofencing/GeofencingService/index.ts
@@ -54,7 +54,7 @@ export class GeofencingServiceLambda extends DeclaredLambdaFunction<Environment,
 			timeout: Duration.seconds(120),
 			environment: {
 				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
-				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
+				MEMORYDB_PORT: memoryDBCluster.port?.toString() || '',
 				EVENT_BUS_NAME: eventBus.eventBusName,
 				SERVICE_NAME: SERVICE_NAME.GEOFENCING_SERVICE,
 			},

--- a/packages/@prototype/api-geotracking/src/ApiGeotracking/GetDriverLocation/index.ts
+++ b/packages/@prototype/api-geotracking/src/ApiGeotracking/GetDriverLocation/index.ts
@@ -51,7 +51,7 @@ export class GetDriverLocationLambda extends DeclaredLambdaFunction<Environment,
 			timeout: Duration.seconds(30),
 			environment: {
 				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
-				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
+				MEMORYDB_PORT: memoryDBCluster.port?.toString() || '',
 
 			},
 			layers: lambdaLayers,

--- a/packages/@prototype/api-geotracking/src/ApiGeotracking/ListDriversForPolygon/index.ts
+++ b/packages/@prototype/api-geotracking/src/ApiGeotracking/ListDriversForPolygon/index.ts
@@ -57,7 +57,7 @@ export class ListDriversForPolygonLambda extends DeclaredLambdaFunction<Environm
 			timeout: Duration.seconds(30),
 			environment: {
 				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
-				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
+				MEMORYDB_PORT: memoryDBCluster.port?.toString() || '',
 				POLYGON_TABLE: geoPolygonTable.tableName,
 				DOMAIN_ENDPOINT: openSearchDomain.domainEndpoint,
 

--- a/packages/@prototype/api-geotracking/src/ApiGeotracking/QueryDrivers/index.ts
+++ b/packages/@prototype/api-geotracking/src/ApiGeotracking/QueryDrivers/index.ts
@@ -51,7 +51,7 @@ export class QueryDriversLambda extends DeclaredLambdaFunction<Environment, Depe
 			timeout: Duration.seconds(30),
 			environment: {
 				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
-				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
+				MEMORYDB_PORT: memoryDBCluster.port?.toString() || '',
 
 			},
 			layers: lambdaLayers,

--- a/packages/@prototype/lambda-functions/src/LambdaFunctions/DriverGeofencingLambda/index.ts
+++ b/packages/@prototype/lambda-functions/src/LambdaFunctions/DriverGeofencingLambda/index.ts
@@ -64,7 +64,7 @@ export class DriverGeofencingtLambda extends DeclaredLambdaFunction<Environment,
 			timeout: Duration.seconds(30),
 			environment: {
 				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
-				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
+				MEMORYDB_PORT: memoryDBCluster.port?.toString() || '',
 				EVENT_BUS: eventBus.eventBusName,
 				SERVICE_NAME: SERVICE_NAME.GEOFENCING_SERVICE,
 			},

--- a/packages/@prototype/lambda-functions/src/LambdaFunctions/DriverLocationCleanupLambda/index.ts
+++ b/packages/@prototype/lambda-functions/src/LambdaFunctions/DriverLocationCleanupLambda/index.ts
@@ -57,7 +57,7 @@ export class DriverLocationCleanupLambda extends DeclaredLambdaFunction<Environm
 			timeout: Duration.seconds(30),
 			environment: {
 				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
-				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
+				MEMORYDB_PORT: memoryDBCluster.port?.toString() || '',
 				DRIVER_LOCATION_UPDATE_TTL_MS: `${driverLocationUpdateTTLInMs}`,
 				DOMAIN_ENDPOINT: openSearchDomain.domainEndpoint,
 

--- a/packages/@prototype/lambda-functions/src/LambdaFunctions/DriverLocationUpdateIngestLambda/index.ts
+++ b/packages/@prototype/lambda-functions/src/LambdaFunctions/DriverLocationUpdateIngestLambda/index.ts
@@ -66,7 +66,7 @@ export class DriverLocationUpdateIngestLambda extends DeclaredLambdaFunction<Env
 			timeout: Duration.seconds(30),
 			environment: {
 				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
-				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
+				MEMORYDB_PORT: memoryDBCluster.port?.toString() || '',
 				DRIVER_LOCATION_UPDATE_TTL_MS: `${driverLocationUpdateTTLInMs}`,
 				DOMAIN_ENDPOINT: openSearchDomain.domainEndpoint,
 			},

--- a/packages/@prototype/lambda-functions/src/LambdaFunctions/DriverStatusUpdateIngestLambda/index.ts
+++ b/packages/@prototype/lambda-functions/src/LambdaFunctions/DriverStatusUpdateIngestLambda/index.ts
@@ -59,7 +59,7 @@ export class DriverStatusUpdateLambda extends DeclaredLambdaFunction<Environment
 			timeout: Duration.seconds(30),
 			environment: {
 				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
-				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
+				MEMORYDB_PORT: memoryDBCluster.port?.toString() || '',
 				EVENT_BUS_NAME: eventBus.eventBusName,
 				SERVICE_NAME: SERVICE_NAME.DRIVER_SERVICE,
 				DOMAIN_ENDPOINT: openSearchDomain.domainEndpoint,

--- a/packages/@prototype/live-data-cache/src/LiveDataCache/MemoryDBCluster/index.ts
+++ b/packages/@prototype/live-data-cache/src/LiveDataCache/MemoryDBCluster/index.ts
@@ -63,7 +63,6 @@ export class MemoryDBCluster extends Construct {
 			// eslint-disable-next-line max-len
 			// https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html#CacheNodes.SupportedTypesByRegion
 			nodeType: nodeType || 'cache.t3.medium',
-
 			autoMinorVersionUpgrade: true,
 			description: 'MemDB for Hyperlocal',
 			numReplicasPerShard: numReplicasPerShard || 1,
@@ -72,6 +71,7 @@ export class MemoryDBCluster extends Construct {
 			securityGroupIds: securityGroups.map(group => group.securityGroupId),
 			subnetGroupName: subnetGroup.ref,
 			tlsEnabled: true,
+			port: 6379,
 		})
 
 		cluster.node.addDependency(subnetGroup)

--- a/packages/@prototype/order-manager/src/OrderManager/OrderManagerHandler/index.ts
+++ b/packages/@prototype/order-manager/src/OrderManager/OrderManagerHandler/index.ts
@@ -56,7 +56,7 @@ export class OrderManagerHandlerLambda extends DeclaredLambdaFunction<Environmen
 			timeout: Duration.seconds(120),
 			environment: {
 				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
-				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
+				MEMORYDB_PORT: memoryDBCluster.port?.toString() || '',
 				ORDER_TABLE: orderTable.tableName,
 				ORDER_ORCHESTRATOR_STATE_MACHINE: orderOrchestrator.stateMachineArn,
 				ORDER_SERVICE_NAME: SERVICE_NAME.ORDER_SERVICE,

--- a/packages/@prototype/order-manager/src/OrderManager/OrderManagerHelper/index.ts
+++ b/packages/@prototype/order-manager/src/OrderManager/OrderManagerHelper/index.ts
@@ -56,7 +56,7 @@ export class OrderManagerHelperLambda extends DeclaredLambdaFunction<Environment
 			timeout: Duration.seconds(120),
 			environment: {
 				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
-				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
+				MEMORYDB_PORT: memoryDBCluster.port?.toString() || '',
 				ORDER_TABLE: orderTable.tableName,
 				EVENT_BUS: eventBus.eventBusArn,
 				SERVICE_NAME: SERVICE_NAME.ORDER_MANAGER,

--- a/packages/@prototype/provider-impl/src/ExamplePollingProvider/lambdas/CancelOrder/index.ts
+++ b/packages/@prototype/provider-impl/src/ExamplePollingProvider/lambdas/CancelOrder/index.ts
@@ -65,7 +65,7 @@ export class CancelOrderLambda extends DeclaredLambdaFunction<Environment, Depen
 			timeout: Duration.seconds(30),
 			environment: {
 				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
-				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
+				MEMORYDB_PORT: memoryDBCluster.port?.toString() || '',
 				EXTERNAL_PROVIDER_URL: externalProviderMockUrl,
 				EXTERNAL_PROVIDER_SECRETNAME: externalProviderSecretName,
 				EVENT_BUS: eventBus.eventBusName,

--- a/packages/@prototype/provider-impl/src/ExamplePollingProvider/lambdas/ExamplePolling/index.ts
+++ b/packages/@prototype/provider-impl/src/ExamplePollingProvider/lambdas/ExamplePolling/index.ts
@@ -68,7 +68,7 @@ export class ExamplePollingLambda extends DeclaredLambdaFunction<Environment, De
 			timeout: Duration.seconds(30),
 			environment: {
 				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
-				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
+				MEMORYDB_PORT: memoryDBCluster.port?.toString() || '',
 				EXTERNAL_PROVIDER_URL: externalProviderMockUrl,
 				EXTERNAL_PROVIDER_SECRETNAME: externalProviderSecretName,
 				EVENT_BUS: eventBus.eventBusName,

--- a/packages/@prototype/provider-impl/src/ExamplePollingProvider/lambdas/GetOrderStatus/index.ts
+++ b/packages/@prototype/provider-impl/src/ExamplePollingProvider/lambdas/GetOrderStatus/index.ts
@@ -65,7 +65,7 @@ export class GetOrderStatusLambda extends DeclaredLambdaFunction<Environment, De
 			timeout: Duration.seconds(30),
 			environment: {
 				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
-				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
+				MEMORYDB_PORT: memoryDBCluster.port?.toString() || '',
 				EXTERNAL_PROVIDER_URL: externalProviderMockUrl,
 				EXTERNAL_PROVIDER_SECRETNAME: externalProviderSecretName,
 				EVENT_BUS: eventBus.eventBusName,

--- a/packages/@prototype/provider-impl/src/ExamplePollingProvider/lambdas/RequestOrderFulfillment/index.ts
+++ b/packages/@prototype/provider-impl/src/ExamplePollingProvider/lambdas/RequestOrderFulfillment/index.ts
@@ -68,7 +68,7 @@ export class RequestOrderFulfillmentLambda extends DeclaredLambdaFunction<Enviro
 			timeout: Duration.seconds(30),
 			environment: {
 				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
-				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
+				MEMORYDB_PORT: memoryDBCluster.port?.toString() || '',
 				EXTERNAL_PROVIDER_URL: externalProviderMockUrl,
 				EXTERNAL_PROVIDER_SECRETNAME: externalProviderSecretName,
 				EVENT_BUS: eventBus.eventBusName,

--- a/packages/@prototype/provider-impl/src/ExampleWebhookProvider/lambdas/CancelOrder/index.ts
+++ b/packages/@prototype/provider-impl/src/ExampleWebhookProvider/lambdas/CancelOrder/index.ts
@@ -65,7 +65,7 @@ export class CancelOrderLambda extends DeclaredLambdaFunction<Environment, Depen
 				SERVICE_NAME: SERVICE_NAME.EXAMPLE_WEBHOOK_PROVIDER_SERVICE,
 				PROVIDER_NAME: PROVIDER_NAME.EXAMPLE_WEBHOOK_PROVIDER,
 				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
-				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
+				MEMORYDB_PORT: memoryDBCluster.port?.toString() || '',
 				EXTERNAL_PROVIDER_URL: externalProviderMockUrl,
 				EXTERNAL_PROVIDER_SECRETNAME: externalProviderSecretName,
 			},

--- a/packages/@prototype/provider-impl/src/ExampleWebhookProvider/lambdas/ExampleCallback/index.ts
+++ b/packages/@prototype/provider-impl/src/ExampleWebhookProvider/lambdas/ExampleCallback/index.ts
@@ -56,7 +56,7 @@ export class ExampleCallbackLambda extends DeclaredLambdaFunction<Environment, D
 			timeout: Duration.seconds(30),
 			environment: {
 				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
-				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
+				MEMORYDB_PORT: memoryDBCluster.port?.toString() || '',
 				EVENT_BUS: eventBus.eventBusName,
 				SERVICE_NAME: SERVICE_NAME.EXAMPLE_WEBHOOK_PROVIDER_SERVICE,
 				PROVIDER_NAME: PROVIDER_NAME.EXAMPLE_WEBHOOK_PROVIDER,

--- a/packages/@prototype/provider-impl/src/ExampleWebhookProvider/lambdas/GetOrderStatus/index.ts
+++ b/packages/@prototype/provider-impl/src/ExampleWebhookProvider/lambdas/GetOrderStatus/index.ts
@@ -65,7 +65,7 @@ export class GetOrderStatusLambda extends DeclaredLambdaFunction<Environment, De
 				SERVICE_NAME: SERVICE_NAME.EXAMPLE_WEBHOOK_PROVIDER_SERVICE,
 				PROVIDER_NAME: PROVIDER_NAME.EXAMPLE_WEBHOOK_PROVIDER,
 				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
-				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
+				MEMORYDB_PORT: memoryDBCluster.port?.toString() || '',
 				EXTERNAL_PROVIDER_URL: externalProviderMockUrl,
 				EXTERNAL_PROVIDER_SECRETNAME: externalProviderSecretName,
 			},

--- a/packages/@prototype/provider-impl/src/ExampleWebhookProvider/lambdas/RequestOrderFulfillment/index.ts
+++ b/packages/@prototype/provider-impl/src/ExampleWebhookProvider/lambdas/RequestOrderFulfillment/index.ts
@@ -58,7 +58,7 @@ export class RequestOrderFulfillmentLambda extends DeclaredLambdaFunction<Enviro
 
 		const environmentVariables = {
 			MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
-			MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
+			MEMORYDB_PORT: memoryDBCluster.port?.toString() || '',
 			EXTERNAL_PROVIDER_URL: externalProviderMockUrl,
 			EXTERNAL_PROVIDER_SECRETNAME: externalProviderSecretName,
 			EVENT_BUS: eventBus.eventBusName,

--- a/packages/@prototype/simulator/src/SimulatorManagerStack/DestinationSimulatorLambda/DestinationStatusUpdateLambda/index.ts
+++ b/packages/@prototype/simulator/src/SimulatorManagerStack/DestinationSimulatorLambda/DestinationStatusUpdateLambda/index.ts
@@ -56,7 +56,7 @@ export class DestinationStatusUpdateLambda extends DeclaredLambdaFunction<Enviro
 			timeout: Duration.seconds(30),
 			environment: {
 				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
-				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
+				MEMORYDB_PORT: memoryDBCluster.port?.toString() || '',
 				EVENT_BUS_NAME: eventBus.eventBusName,
 				SERVICE_NAME: SERVICE_NAME.DESTINATION_SERVICE,
 			},

--- a/packages/@prototype/simulator/src/SimulatorManagerStack/OriginSimulatorLambda/OriginStatusUpdateLambda/index.ts
+++ b/packages/@prototype/simulator/src/SimulatorManagerStack/OriginSimulatorLambda/OriginStatusUpdateLambda/index.ts
@@ -56,7 +56,7 @@ export class OriginStatusUpdateLambda extends DeclaredLambdaFunction<Environment
 			timeout: Duration.seconds(30),
 			environment: {
 				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
-				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
+				MEMORYDB_PORT: memoryDBCluster.port?.toString() || '',
 				EVENT_BUS_NAME: eventBus.eventBusName,
 				SERVICE_NAME: SERVICE_NAME.ORIGIN_SERVICE,
 			},

--- a/packages/@prototype/simulator/src/SimulatorManagerStack/OriginSimulatorLambda/index.ts
+++ b/packages/@prototype/simulator/src/SimulatorManagerStack/OriginSimulatorLambda/index.ts
@@ -132,7 +132,7 @@ export class OriginSimulatorLambda extends Construct {
 			timeout: Duration.seconds(120),
 			environment: {
 				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
-				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
+				MEMORYDB_PORT: memoryDBCluster.port?.toString() || '',
 				ORIGIN_TABLE: originTable.tableName,
 				ORIGIN_SIMULATIONS_TABLE_NAME: originSimulationsTable.tableName,
 				ORIGIN_STATS_TABLE_NAME: originStatsTable.tableName,

--- a/packages/@prototype/simulator/src/SimulatorManagerStack/StatisticsLambda/index.ts
+++ b/packages/@prototype/simulator/src/SimulatorManagerStack/StatisticsLambda/index.ts
@@ -54,7 +54,7 @@ export class StatisticsLambda extends Construct {
 			timeout: Duration.seconds(120),
 			environment: {
 				MEMORYDB_HOST: memoryDBCluster.attrClusterEndpointAddress,
-				MEMORYDB_PORT: `${memoryDBCluster.attrClusterEndpointPort}`,
+				MEMORYDB_PORT: memoryDBCluster.port?.toString() || '',
 				DISPATCH_ENGINE_SERVICE: SERVICE_NAME.DISPATCH_ENGINE,
 				ORDER_SERVICE_NAME: SERVICE_NAME.ORDER_SERVICE,
 				DRIVER_SERVICE_NAME: SERVICE_NAME.DRIVER_SERVICE,


### PR DESCRIPTION
*Issue #, if available:* NA, error present on CDK (see https://github.com/aws/aws-cdk/issues/18282 )

*Description of changes:*

- add workaround to enforce the default Redis port to MemoryDB and use that value in the Lambda environment variable. The previous version had issues as per link above 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
