### PR TITLE
fix(lambda): fix nohoist configuration to add nanoid

### DIFF
--- a/packages/@prototype/simulator/src/SimulatorManagerStack/DestinationSimulatorLambda/DestinationGeneratorStepFunction/@lambda/package.json
+++ b/packages/@prototype/simulator/src/SimulatorManagerStack/DestinationSimulatorLambda/DestinationGeneratorStepFunction/@lambda/package.json
@@ -22,8 +22,8 @@
       "**/uuid/**",
       "**/aws-amplify",
       "**/aws-amplify/**",
-      "**/shortid",
-      "**/shortid/**"
+      "**/nanoid",
+      "**/nanoid/**"
     ]
   }
 }

--- a/packages/@prototype/simulator/src/SimulatorManagerStack/OriginSimulatorLambda/OriginGeneratorStepFunction/@lambda/package.json
+++ b/packages/@prototype/simulator/src/SimulatorManagerStack/OriginSimulatorLambda/OriginGeneratorStepFunction/@lambda/package.json
@@ -22,8 +22,8 @@
       "**/uuid/**",
       "**/aws-amplify",
       "**/aws-amplify/**",
-      "**/shortid",
-      "**/shortid/**"
+      "**/nanoid",
+      "**/nanoid/**"
     ]
   }
 }


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:*

- fix `nohoist` configuration on lambdas to include `nanoid` instead of the deprecated `shortid`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
