### PR TITLE
feat(graphhopper): docker build with skipTest as it's failing on x86

### DIFF
--- a/packages/@prototype/dispatch-setup/src/GraphhopperSetup/docker/Dockerfile
+++ b/packages/@prototype/dispatch-setup/src/GraphhopperSetup/docker/Dockerfile
@@ -9,11 +9,12 @@ WORKDIR /build
 
 # fetch graphhopper, make some finetune in the pom.xml and build it
 RUN \
-    git clone --depth 2 https://github.com/graphhopper/graphhopper.git \
+    git clone --depth 1 --branch 4.0 https://github.com/graphhopper/graphhopper.git \
     && cd graphhopper \
     && sed -i 's/nodeVersion>v12.3.1/nodeVersion>v17.2.0/' web-bundle/pom.xml \
-    && sed -i 's/npmVersion>6.14.5/npmVersion>8.1.4/' web-bundle/pom.xml \
-    && mvn clean package --quiet
+    && sed -i 's/npmVersion>6.14.5/npmVersion>8.1.4/' web-bundle/pom.xml
+
+RUN cd graphhopper && mvn clean package --quiet -DskipTests=true
 
 # fetch the mapfile
 RUN mkdir -p /map && wget -O /map/mapfile.osm.pbf ${MAPFILE_URL}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* fix graphhopper version with `4.0` tag when checking out to build for docker
* build graphhopper with `-DskipTests=true` switch as build fails on x86

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
