### PR TITLE
fix(infra): fix redis commands for geo functions

### DIFF
--- a/packages/@prototype/api-geotracking/src/ApiGeofencing/GeofencingService/@lambda/src/http/post.js
+++ b/packages/@prototype/api-geotracking/src/ApiGeofencing/GeofencingService/@lambda/src/http/post.js
@@ -57,7 +57,7 @@ module.exports.default = async (event) => {
 		//   - 1 = enter geofence
 		//   - 2 = exit geofence
 		await redis.hSet(GEOFENCE_LOCATION_STATUS, geofenceId, `0,${radius},${driverId}`)
-		await redis.geoAdd(GEOFENCE_LOCATION, long, lat, geofenceId)
+		await redis.geoAdd(GEOFENCE_LOCATION, { longitude: long, latitude: lat, member: geofenceId })
 
 		await eventBridge.putEvent('GEOFENCE_START', {
 			id: geofenceId,

--- a/packages/@prototype/api-geotracking/src/ApiGeotracking/GetDemAreaSettings/@lambda/index.js
+++ b/packages/@prototype/api-geotracking/src/ApiGeotracking/GetDemAreaSettings/@lambda/index.js
@@ -33,9 +33,9 @@ const handler = async (event) => {
 
 		return success(result.Items)
 	} catch (err) {
-		console.error(`Error while retrieving demographic area settings: ${JSON.stringify(err)}`)
+		console.error('Error while retrieving demographic area settings', err)
 
-		return fail({ message: JSON.stringify(err) })
+		return fail({ message: 'Error retrieving demographic area settings' })
 	}
 }
 

--- a/packages/@prototype/api-geotracking/src/ApiGeotracking/GetDriverLocation/@lambda/index.js
+++ b/packages/@prototype/api-geotracking/src/ApiGeotracking/GetDriverLocation/@lambda/index.js
@@ -52,9 +52,9 @@ const handler = async (event) => {
 
 		return success(JSON.parse(driverData))
 	} catch (err) {
-		console.error(`Error while retreiving driver location: ${JSON.stringify(err)}`)
+		console.error('Error while retrieving driver location:', err)
 
-		return fail({ message: `Error while retreiving driver location: ${JSON.stringify(err)}` })
+		return fail({ message: 'Error while retrieving driver location' })
 	}
 }
 

--- a/packages/@prototype/api-geotracking/src/ApiGeotracking/ListDriversForPolygon/@lambda/index.js
+++ b/packages/@prototype/api-geotracking/src/ApiGeotracking/ListDriversForPolygon/@lambda/index.js
@@ -46,7 +46,7 @@ const handleGET = async (event) => {
 	}
 
 	try {
-		console.debug(`retreiving polygon :: ${JSON.stringify(params)}`)
+		console.debug(`retrieving polygon :: ${JSON.stringify(params)}`)
 		let result = await ddbClient.get(params).promise()
 		console.debug(`ddb polygon result :: ${JSON.stringify(result)}`)
 		const { vertices } = result.Item
@@ -54,9 +54,9 @@ const handleGET = async (event) => {
 
 		return success(result)
 	} catch (err) {
-		console.error(`Error while searching for drivers by polygonId: ${JSON.stringify(err)}`)
+		console.error('Error while searching for drivers by polygonId: ', err)
 
-		return fail({ message: JSON.stringify(err) })
+		return fail({ message: `Error while searching for drivers by polygonId: ${polygonId}` })
 	}
 }
 

--- a/packages/@prototype/appconfig/src/AppConfigNestedStack/DeploymentHandlerLambda/@lambda/index.js
+++ b/packages/@prototype/appconfig/src/AppConfigNestedStack/DeploymentHandlerLambda/@lambda/index.js
@@ -83,7 +83,7 @@ exports.handler = async (event) => {
 					qos: 1,
 				}).promise()
 			} catch (err) {
-				console.error(`Error :: ${JSON.stringify(err)}`)
+				console.error('Deployment Error :: ', err)
 			}
 		}
 	}

--- a/packages/@prototype/external-provider-mock/src/ExternalPollingProviderStack/ServiceLambda/@lambda/src/utils/index.js
+++ b/packages/@prototype/external-provider-mock/src/ExternalPollingProviderStack/ServiceLambda/@lambda/src/utils/index.js
@@ -24,13 +24,13 @@ const success = body => {
 	}
 }
 
-const fail = (err, statusCode) => {
+const fail = (errorObj, statusCode) => {
 	return {
 		statusCode: statusCode || 500,
 		headers: {
 			'Access-Control-Allow-Origin': '*',
 		},
-		body: JSON.stringify(err),
+		body: JSON.stringify(errorObj),
 	}
 }
 

--- a/packages/@prototype/external-provider-mock/src/ExternalProviderSetup/@lambda/index.js
+++ b/packages/@prototype/external-provider-mock/src/ExternalProviderSetup/@lambda/index.js
@@ -45,8 +45,9 @@ const handleRequest = async (apiKeySecretNameList) => {
 				includeValue: true,
 			}).promise()
 		} catch (err) {
-			console.error(`Error while retreiveing apiKey with ID ${apiKeySecretName.keyId}: ${JSON.stringify(err)}`)
+			console.error(`Error while retreiveing apiKey with ID ${apiKeySecretName.keyId}:`, err)
 			console.error(`Skipping ${JSON.stringify(apiKeySecretName)}`)
+
 			continue
 		}
 
@@ -55,7 +56,7 @@ const handleRequest = async (apiKeySecretNameList) => {
 				SecretId: apiKeySecretName.secret,
 			}).promise()
 		} catch (err) {
-			console.warn(`Error while retreiving secret ${apiKeySecretName.secret} from secretsManager: ${JSON.stringify(err)}`)
+			console.warn(`Error while retrieving secret ${apiKeySecretName.secret} from secretsManager:`, err)
 		}
 
 		// secret doesn't exist, create it
@@ -66,7 +67,7 @@ const handleRequest = async (apiKeySecretNameList) => {
 					SecretString: apiKey.value,
 				}).promise()
 			} catch (err) {
-				console.error(`Error while creating secret ${apiKeySecretName.secret} in secretsManager: ${JSON.stringify(err)}`)
+				console.error(`Error while creating secret ${apiKeySecretName.secret} in secretsManager:`, err)
 			}
 		// secret exists, update it
 		} else {
@@ -76,7 +77,7 @@ const handleRequest = async (apiKeySecretNameList) => {
 					SecretString: apiKey.value,
 				}).promise()
 			} catch (err) {
-				console.error(`Error while updating secret ${apiKeySecretName.secret} in secretsManager: ${JSON.stringify(err)}`)
+				console.error(`Error while updating secret ${apiKeySecretName.secret} in secretsManager: `, err)
 			}
 		}
 	}

--- a/packages/@prototype/external-provider-mock/src/ExternalWebhookProviderStack/ServiceLambda/@lambda/src/utils/index.js
+++ b/packages/@prototype/external-provider-mock/src/ExternalWebhookProviderStack/ServiceLambda/@lambda/src/utils/index.js
@@ -24,13 +24,13 @@ const success = body => {
 	}
 }
 
-const fail = (err, statusCode) => {
+const fail = (errorObj, statusCode) => {
 	return {
 		statusCode: statusCode || 500,
 		headers: {
 			'Access-Control-Allow-Origin': '*',
 		},
-		body: JSON.stringify(err),
+		body: JSON.stringify(errorObj),
 	}
 }
 

--- a/packages/@prototype/lambda-common/src/LambdaUtils/@lambda/index.js
+++ b/packages/@prototype/lambda-common/src/LambdaUtils/@lambda/index.js
@@ -26,13 +26,13 @@ const success = body => {
 	}
 }
 
-const fail = (err, statusCode) => {
+const fail = (errorObj, statusCode) => {
 	return {
 		statusCode: statusCode || 500,
 		headers: {
 			'Access-Control-Allow-Origin': '*',
 		},
-		body: JSON.stringify(err),
+		body: JSON.stringify(errorObj),
 	}
 }
 

--- a/packages/@prototype/lambda-common/src/RedisClientLayer/@lambda/index.js
+++ b/packages/@prototype/lambda-common/src/RedisClientLayer/@lambda/index.js
@@ -18,32 +18,60 @@ const redis = require('redis')
 const awsSdk = require('aws-sdk')
 
 const secrets = new awsSdk.SecretsManager()
-let client = null
+const clients = {}
 
-exports.getRedisClient = async () => {
-	if (client == null) {
-		const adminPassword = await secrets.getSecretValue({
+const generateClientId = (options) => {
+	// Java's hashCode method converted to js
+	const hashCode = (str) => {
+		let hash = 0; let i = 0; const len = str.length
+		while (i < len) {
+			hash = ((hash << 5) - hash + str.charCodeAt(i++)) << 0
+		}
+
+		return hash
+	}
+
+	return hashCode(JSON.stringify(options))
+}
+
+exports.getRedisClient = async (options = { clusterMode: true, readonly: false, useReplicas: true }) => {
+	const clientId = generateClientId(options)
+	const { clusterMode, readonly, useReplicas } = options
+
+	if (!clients[clientId]) {
+		const memoryDbAdminPassword = await secrets.getSecretValue({
 			SecretId: process.env.MEMORYDB_ADMIN_SECRET,
 		}).promise()
 
-		client = redis.createCluster({
-			rootNodes: [{
-				url: `redis://${process.env.MEMORYDB_HOST}:${process.env.MEMORYDB_PORT}`,
-			}],
-			useReplicas: true,
-			defaults: {
-				socket: {
-					tls: true,
-				},
-				username: process.env.MEMORYDB_ADMIN_USERNAME,
-				password: adminPassword.SecretString,
+		const url = `rediss://${process.env.MEMORYDB_HOST}:${process.env.MEMORYDB_PORT}`
+		const redisOptions = {
+			socket: {
+				tls: true,
 			},
-		})
+			username: process.env.MEMORYDB_ADMIN_USERNAME,
+			password: memoryDbAdminPassword.SecretString,
+		}
 
-		await client.connect()
+		clients[clientId] = clusterMode
+			? redis.createCluster({
+				rootNodes: [{
+					url,
+				}],
+				useReplicas,
+				defaults: {
+					...redisOptions,
+				},
+			})
+			: redis.createClient({
+				url,
+				readonly,
+				...redisOptions,
+			})
+
+		await clients[clientId].connect()
 	}
 
-	return client
+	return clients[clientId]
 }
 
 exports.redis = redis

--- a/packages/@prototype/lambda-functions/src/LambdaFunctions/DriverGeofencingLambda/@lambda/geofencing/index.js
+++ b/packages/@prototype/lambda-functions/src/LambdaFunctions/DriverGeofencingLambda/@lambda/geofencing/index.js
@@ -46,7 +46,7 @@ const evaluateGeofence = async (driverId, location, geofenceId) => {
 		throw new Error('Mismatch between location driver and geofence driver, skipping')
 	}
 
-	await redisClient.geoAdd(GEOFENCE_LOCATION, longitude, latitude, driverId)
+	await redisClient.geoAdd(GEOFENCE_LOCATION, { longitude, latitude, member: driverId })
 	const dst = await redisClient.geoDist(GEOFENCE_LOCATION, geofenceId, driverId)
 	const distance = Number(dst)
 

--- a/packages/@prototype/lambda-functions/src/LambdaFunctions/DriverGeofencingLambda/@lambda/index.js
+++ b/packages/@prototype/lambda-functions/src/LambdaFunctions/DriverGeofencingLambda/@lambda/index.js
@@ -61,7 +61,7 @@ const handler = async (event, context) => {
 					break
 			}
 		} catch (err) {
-			console.error(`Error updating Elasticache :: ${data.type} :: ${JSON.stringify(err)}`)
+			console.error(`Error updating MemoryDB :: ${data.type} ::`, err)
 		}
 	}
 }

--- a/packages/@prototype/lambda-functions/src/LambdaFunctions/DriverLocationCleanupLambda/@lambda/index.js
+++ b/packages/@prototype/lambda-functions/src/LambdaFunctions/DriverLocationCleanupLambda/@lambda/index.js
@@ -35,13 +35,13 @@ const handler = async () => {
 	const now = Date.now()
 
 	try {
-		console.debug('Retreiving all drivers who have not updated their status until TTL', now)
+		console.debug('retrieving all drivers who have not updated their status until TTL', now)
 		driverIds = await redisClient.zRangeByScore(DRIVER_LOCATION_TTLS, '-inf', now)
 
 		// console.debug(`Drivers who expired: ${JSON.stringify(driverIds)}`)
 		console.debug(`${driverIds.length} drivers expired`)
 	} catch (err) {
-		console.error(`Error while retreiving expired drivers: ${JSON.stringify(err)}`)
+		console.error('Error while retrieving expired drivers: ', err)
 
 		return
 	}
@@ -124,7 +124,7 @@ const handler = async () => {
 		})
 		// -------------------------------------------------------------------------------------------------------------
 	} catch (err) {
-		console.error(`Error removing key from Elasticache: ${JSON.stringify(err)}`)
+		console.error('Error removing key from MemoryDB: ', err)
 	}
 	console.debug(`Successfully removed all expired drivers from ${DRIVER_LOCATION}/${DRIVER_LOCATION_RAW}/${DRIVER_LOCATION_TTLS}`)
 }

--- a/packages/@prototype/lambda-functions/src/LambdaFunctions/DriverStatusUpdateIngestLambda/@lambda/index.js
+++ b/packages/@prototype/lambda-functions/src/LambdaFunctions/DriverStatusUpdateIngestLambda/@lambda/index.js
@@ -49,7 +49,7 @@ const handler = async (event, context) => {
 		await client.hSet(DRIVER_STATUS_UPDATED_AT, driverId, timestamp)
 		console.debug(`STATUS_CHANGE :: ${event.driverId} :: Successfully updated Redis`)
 	} catch (err) {
-		console.error(`Error updating Redis :: ${event.type} :: ${JSON.stringify(err)}`)
+		console.error(`Error updating MemoryDB :: ${event.type} :: `, err)
 	}
 
 	try {
@@ -65,7 +65,7 @@ const handler = async (event, context) => {
 		})
 		console.debug(`STATUS_CHANGE :: ${event.driverId} :: Successfully updated OPENSEARCH`)
 	} catch (err) {
-		console.error(`Error updating Elasticache :: ${event.type} :: ${JSON.stringify(err)}`)
+		console.error(`Error updating OpenSearch :: ${event.type} :: `, err)
 	}
 
 	try {
@@ -80,7 +80,7 @@ const handler = async (event, context) => {
 
 		console.debug(`STATUS_CHANGE :: ${event.driverId} :: Successfully sent to Event Bridge`)
 	} catch (err) {
-		console.error(`Error sending message to Event Bridge :: ${event.type} :: ${JSON.stringify(err)}`)
+		console.error(`Error sending message to Event Bridge :: ${event.type} :: `, err)
 	}
 }
 

--- a/packages/@prototype/lambda-functions/src/LambdaFunctions/OpenSearchInitialSetupLambda/@lambda/index.js
+++ b/packages/@prototype/lambda-functions/src/LambdaFunctions/OpenSearchInitialSetupLambda/@lambda/index.js
@@ -63,7 +63,7 @@ const handleCreate = async () => {
 		result = await openSearchClient.indices.putMapping(mappingObj)
 		console.log(`Successfully updated index ${DRIVER_LOCATION_INDEX}. Result: ${JSON.stringify(result)}`)
 	} catch (err) {
-		console.log(`Error while creating index ${DRIVER_LOCATION_INDEX}. Updating instead. Error: ${JSON.stringify(err)}`)
+		console.log(`Error while creating index ${DRIVER_LOCATION_INDEX}. Updating instead. Error: `, err)
 
 		await handleUpdate()
 	}
@@ -74,7 +74,7 @@ const handleUpdate = async () => {
 		const result = await openSearchClient.indices.putMapping(mappingObj)
 		console.log(`Successfully updated index ${DRIVER_LOCATION_INDEX}. Result: ${JSON.stringify(result)}`)
 	} catch (err) {
-		console.log(`Error while updating index ${DRIVER_LOCATION_INDEX}. Error: ${JSON.stringify(err)}`)
+		console.log(`Error while updating index ${DRIVER_LOCATION_INDEX}. Error: `, err)
 	}
 }
 

--- a/packages/@prototype/live-data-cache/src/LiveDataCache/OpenSearchCluster/OpenSearchInitialSetup/@lambda/index.js
+++ b/packages/@prototype/live-data-cache/src/LiveDataCache/OpenSearchCluster/OpenSearchInitialSetup/@lambda/index.js
@@ -29,10 +29,10 @@ const onEvent = async (event) => {
 	}
 
 	try {
-		const resp = await lambda.invoke(params).promise()
+		await lambda.invoke(params).promise()
 		console.log(`Successfully called ${SETUP_LAMBDA_ARN}`)
 	} catch (err) {
-		console.error(`Error while calling ${SETUP_LAMBDA_ARN}: ${JSON.stringify(err)}`)
+		console.error(`Error while calling ${SETUP_LAMBDA_ARN}: `, err)
 	}
 }
 

--- a/packages/@prototype/provider-impl/src/InstantDeliveryProvider/lambdas/CancelOrder/@lambda/index.js
+++ b/packages/@prototype/provider-impl/src/InstantDeliveryProvider/lambdas/CancelOrder/@lambda/index.js
@@ -56,7 +56,7 @@ const handler = async (event, context) => {
 
 		return success()
 	} catch (err) {
-		console.error(`Error sending ORDER_CANCELLED message to Event Bridge :: ${orderId} :: ${JSON.stringify(err)}`)
+		console.error(`Error sending ORDER_CANCELLED message to Event Bridge :: ${orderId} :: `, err)
 	}
 }
 

--- a/packages/@prototype/provider-impl/src/InstantDeliveryProvider/lambdas/GetOrderStatus/@lambda/index.js
+++ b/packages/@prototype/provider-impl/src/InstantDeliveryProvider/lambdas/GetOrderStatus/@lambda/index.js
@@ -39,9 +39,9 @@ const handler = async (event, context) => {
 			return fail({ message: `Unable to find order with ID ${orderId}` }, 404)
 		}
 	} catch (err) {
-		console.error(`Error :: ${JSON.stringify(err)}`)
+		console.error('Get order status error :: ', err)
 
-		return fail({ error: err })
+		return fail({ error: 'Error retrieving the order status' })
 	}
 }
 

--- a/packages/@prototype/provider/src/ProviderInitialSetup/@lambda/index.js
+++ b/packages/@prototype/provider/src/ProviderInitialSetup/@lambda/index.js
@@ -56,7 +56,7 @@ const handleRequest = async (apiKeySecretNameList) => {
 				includeValue: true,
 			}).promise()
 		} catch (err) {
-			console.error(`Error while retreiveing apiKey with ID ${apiKeySecretName.keyId}: ${JSON.stringify(err)}`)
+			console.error(`Error while retreiveing apiKey with ID ${apiKeySecretName.keyId}: `, err)
 			console.error(`Skipping ${JSON.stringify(apiKeySecretName)}`)
 			continue
 		}
@@ -66,7 +66,7 @@ const handleRequest = async (apiKeySecretNameList) => {
 				SecretId: apiKeySecretName.secret,
 			}).promise()
 		} catch (err) {
-			console.warn(`Error while retreiving secret ${apiKeySecretName.secret} from secretsManager: ${JSON.stringify(err)}`)
+			console.warn(`Error while retrieving secret ${apiKeySecretName.secret} from secretsManager: `, err)
 		}
 
 		// secret doesn't exist, create it
@@ -77,7 +77,7 @@ const handleRequest = async (apiKeySecretNameList) => {
 					SecretString: apiKey.value,
 				}).promise()
 			} catch (err) {
-				console.error(`Error while creating secret ${apiKeySecretName.secret} in secretsManager: ${JSON.stringify(err)}`)
+				console.error(`Error while creating secret ${apiKeySecretName.secret} in secretsManager:`, err)
 			}
 		// secret exists, update it
 		} else {
@@ -87,7 +87,7 @@ const handleRequest = async (apiKeySecretNameList) => {
 					SecretString: apiKey.value,
 				}).promise()
 			} catch (err) {
-				console.error(`Error while updating secret ${apiKeySecretName.secret} in secretsManager: ${JSON.stringify(err)}`)
+				console.error(`Error while updating secret ${apiKeySecretName.secret} in secretsManager: `, err)
 			}
 		}
 	}

--- a/packages/@prototype/simulator/src/SimulatorManagerStack/DestinationSimulatorLambda/DestinationStatusUpdateLambda/@lambda/index.js
+++ b/packages/@prototype/simulator/src/SimulatorManagerStack/DestinationSimulatorLambda/DestinationStatusUpdateLambda/@lambda/index.js
@@ -38,7 +38,7 @@ const handler = async (event, context) => {
 
 		console.debug(`STATUS_CHANGE :: ${event.destinationId} :: Successfully sent to Event Bridge`)
 	} catch (err) {
-		console.error(`Error sending message to Event Bridge :: ${event.type} :: ${JSON.stringify(err)}`)
+		console.error(`Error sending message to Event Bridge :: ${event.type} :: `, err)
 	}
 
 	if (event.type !== 'STATUS_CHANGE') {
@@ -58,7 +58,8 @@ const handler = async (event, context) => {
 	const client = await getRedisClient()
 
 	try {
-		let statusList = await client.sendCommand(['KEYS', `${DESTINATION_STATUS}:*`])
+		const keyClient = await getRedisClient({ clusterMode: false })
+		let statusList = await keyClient.keys(`${DESTINATION_STATUS}:*`)
 		statusList = (statusList || []).map(q => q.split(':').pop())
 
 		if (statusList.length === 0) {
@@ -85,7 +86,7 @@ const handler = async (event, context) => {
 
 		console.debug(`STATUS_CHANGE :: ${destinationId} :: Successfully updated Redis`)
 	} catch (err) {
-		console.error(`Error updating Redis :: ${event.type} :: ${JSON.stringify(err)}`)
+		console.error(`Error updating MemoryDB :: ${event.type} :: `, err)
 		console.error(err)
 	}
 }

--- a/packages/@prototype/simulator/src/SimulatorManagerStack/DispatcherAssignmentQueryLambda/@lambda/index.js
+++ b/packages/@prototype/simulator/src/SimulatorManagerStack/DispatcherAssignmentQueryLambda/@lambda/index.js
@@ -107,9 +107,9 @@ const handler = async (event) => {
 
 		return success({ data: { assignments, nextToken } })
 	} catch (err) {
-		console.error(`There was an error while retrieving ${NAME}s: ${JSON.stringify(err)}`)
+		console.error(`There was an error while retrieving ${NAME}s: `, err)
 
-		return fail({ error: err })
+		return fail({ error: `Error while retrieving ${NAME}s` })
 	}
 }
 

--- a/packages/@prototype/simulator/src/SimulatorManagerStack/OriginSimulatorLambda/OriginStatusUpdateLambda/@lambda/index.js
+++ b/packages/@prototype/simulator/src/SimulatorManagerStack/OriginSimulatorLambda/OriginStatusUpdateLambda/@lambda/index.js
@@ -38,7 +38,7 @@ const handler = async (event, context) => {
 
 		console.debug(`STATUS_CHANGE :: ${event.originId} :: Successfully sent to Event Bridge`)
 	} catch (err) {
-		console.error(`Error sending message to Event Bridge :: ${event.type} :: ${JSON.stringify(err)}`)
+		console.error(`Error sending message to Event Bridge :: ${event.type} :: `, err)
 	}
 
 	if (event.type !== 'STATUS_CHANGE') {
@@ -58,7 +58,8 @@ const handler = async (event, context) => {
 	const client = await getRedisClient()
 
 	try {
-		let statusList = await client.sendCommand(['KEYS', `${ORIGIN_STATUS}:*`])
+		const keyClient = await getRedisClient({ clusterMode: false })
+		let statusList = await keyClient.keys(`${ORIGIN_STATUS}:*`)
 		statusList = (statusList || []).map(q => q.split(':').pop())
 
 		if (statusList.length === 0) {
@@ -85,7 +86,7 @@ const handler = async (event, context) => {
 
 		console.debug(`STATUS_CHANGE :: ${originId} :: Successfully updated Redis`)
 	} catch (err) {
-		console.error(`Error updating Redis :: ${event.type} :: ${JSON.stringify(err)}`)
+		console.error(`Error updating Redis :: ${event.type} :: `, err)
 		console.error(err)
 	}
 }

--- a/packages/@prototype/simulator/src/SimulatorManagerStack/PolygonManagerLambda/@lambda/lib/create.js
+++ b/packages/@prototype/simulator/src/SimulatorManagerStack/PolygonManagerLambda/@lambda/lib/create.js
@@ -59,9 +59,9 @@ const handler = async (event) => {
 
 		return success({ data })
 	} catch (err) {
-		console.error(`:: ${NAME}-manager :: There was an error while creating a ${NAME} record: ${JSON.stringify(err)}`)
+		console.error(`:: ${NAME}-manager :: There was an error while creating a ${NAME} record: `, err)
 
-		return fail({ error: err })
+		return fail({ error: `There was an error while creating a ${NAME} record` })
 	}
 }
 

--- a/packages/@prototype/simulator/src/SimulatorManagerStack/PolygonManagerLambda/@lambda/lib/delete.js
+++ b/packages/@prototype/simulator/src/SimulatorManagerStack/PolygonManagerLambda/@lambda/lib/delete.js
@@ -47,9 +47,9 @@ const handler = async (event) => {
 
 			return success({ data })
 		} catch (err) {
-			console.error(`:: ${NAME}-manager :: DELETE :: There was an error while deleting ${NAME} with id ${entityId}: ${JSON.stringify(err)}`)
+			console.error(`:: ${NAME}-manager :: DELETE :: There was an error while deleting ${NAME} with id ${entityId}: `, err)
 
-			return fail({ error: err })
+			return fail({ error: `There was an error while deleting ${NAME} with id ${entityId}: ` })
 		}
 	}
 }

--- a/packages/@prototype/simulator/src/SimulatorManagerStack/PolygonManagerLambda/@lambda/lib/get.js
+++ b/packages/@prototype/simulator/src/SimulatorManagerStack/PolygonManagerLambda/@lambda/lib/get.js
@@ -50,9 +50,9 @@ const handler = async (event) => {
 
 		return success({ data: result })
 	} catch (err) {
-		console.error(`There was an error while retrieving ${NAME}s: ${JSON.stringify(err)}`)
+		console.error(`There was an error while retrieving ${NAME}s: `, err)
 
-		return fail({ error: err })
+		return fail({ error: `There was an error while retrieving ${NAME}s` })
 	}
 }
 

--- a/packages/@prototype/simulator/src/SimulatorManagerStack/PolygonManagerLambda/@lambda/lib/update.js
+++ b/packages/@prototype/simulator/src/SimulatorManagerStack/PolygonManagerLambda/@lambda/lib/update.js
@@ -58,9 +58,9 @@ const handler = async (event) => {
 
 		return success({ data })
 	} catch (err) {
-		console.error(`:: ${NAME}-manager :: There was an error while updating a ${NAME} record: ${JSON.stringify(err)}`)
+		console.error(`:: ${NAME}-manager :: There was an error while updating a ${NAME} record:`, err)
 
-		return fail({ error: err })
+		return fail({ error: `There was an error while updating a ${NAME} record` })
 	}
 }
 

--- a/packages/@prototype/simulator/src/SimulatorManagerStack/StatisticsLambda/@lambda/src/builders/driver.js
+++ b/packages/@prototype/simulator/src/SimulatorManagerStack/StatisticsLambda/@lambda/src/builders/driver.js
@@ -24,8 +24,9 @@ const { DRIVER_STATUS_STATISTICS } = REDIS_HASH
 const mapper = {
 	DRIVER_STATUS_CHANGE: async (detail) => {
 		const client = await getRedisClient()
+		const keyClient = await getRedisClient({ clusterMode: false })
 		const { driverId, status, timestamp } = detail
-		let statusList = await client.sendCommand(['KEYS', `${DRIVER_STATUS_STATISTICS}:*`])
+		let statusList = await keyClient.keys(`${DRIVER_STATUS_STATISTICS}:*`)
 		statusList = (statusList || []).map(q => q.split(':').pop())
 
 		if (statusList.length === 0) {

--- a/packages/@prototype/simulator/src/SimulatorManagerStack/StatisticsLambda/@lambda/src/builders/order.js
+++ b/packages/@prototype/simulator/src/SimulatorManagerStack/StatisticsLambda/@lambda/src/builders/order.js
@@ -32,9 +32,10 @@ const mapper = {
 	},
 	ORDER_UPDATE: async (detail) => {
 		const client = await getRedisClient()
+		const keyClient = await getRedisClient({ clusterMode: false })
 		const timestamp = Date.now()
 		const { ID, state, provider, assignedAt, updatedAt } = detail
-		let statusList = await client.sendCommand(['KEYS', `${ORDER_STATUS}:*`])
+		let statusList = await keyClient.keys(`${ORDER_STATUS}:*`)
 		statusList = (statusList || []).map(q => q.split(':').pop())
 
 		if (statusList.length === 0) {

--- a/packages/@prototype/simulator/src/SimulatorManagerStack/StatisticsLambda/@lambda/src/builders/providerManager.js
+++ b/packages/@prototype/simulator/src/SimulatorManagerStack/StatisticsLambda/@lambda/src/builders/providerManager.js
@@ -40,9 +40,10 @@ const mapper = {
 	},
 	ORDER_UPDATE: async (providerName, detail) => {
 		const client = await getRedisClient()
+		const keyClient = await getRedisClient({ clusterMode: false })
 		const timestamp = Date.now()
 		const { orderId, status } = detail
-		let statusList = await client.sendCommand(['KEYS', `${PROVIDER_DISTRIBUTION}:${providerName}:*`])
+		let statusList = await keyClient.keys(`${PROVIDER_DISTRIBUTION}:${providerName}:*`)
 		statusList = (statusList || []).map(q => q.split(':').pop())
 
 		if (statusList.length === 0) {

--- a/packages/@prototype/simulator/src/SimulatorManagerStack/StatisticsLambda/@lambda/src/commands/getStats.js
+++ b/packages/@prototype/simulator/src/SimulatorManagerStack/StatisticsLambda/@lambda/src/commands/getStats.js
@@ -34,7 +34,8 @@ const {
 
 const getStatusCount = async (hashKey) => {
 	const client = await getRedisClient()
-	const statusList = await client.sendCommand(['KEYS', `${hashKey}:*`])
+	const keyClient = await getRedisClient({ clusterMode: false })
+	const statusList = await keyClient.keys(`${hashKey}:*`)
 	const result = {}
 
 	for (let i = 0; i < statusList.length; i++) {


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* 

- fix redis geo functions to use the v4 syntax to execute new commands
- use new `geoSearch` method available in Redis 6.2
- add the ability to create a redis client without cluster mode (some commands seems not supported with a cluster client)
- refactor occurrences of `JSON.stringify(err)` 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
