### PR TITLE
fix(simulator): swap origin/destination properties

### DIFF
--- a/prototype/infra/lib/stack/root/SimulatorMainStack/index.ts
+++ b/prototype/infra/lib/stack/root/SimulatorMainStack/index.ts
@@ -135,8 +135,8 @@ export class SimulatorMainStack extends Stack {
 			cluster: ecsContainerStack.cluster,
 
 			driverSimulatorContainer: ecsContainerStack.driverSimulator,
-			originSimulatorContainer: ecsContainerStack.destinationSimulator,
-			destinationSimulatorContainer: ecsContainerStack.originSimulator,
+			originSimulatorContainer: ecsContainerStack.originSimulator,
+			destinationSimulatorContainer: ecsContainerStack.destinationSimulator,
 
 			originTable: dataStack.originTable,
 			originAreaIndex: dataStack.originAreaIndex,


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:*

- swap origin/destination ecs task variables as they were linked to the wrong property


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
