### PR TITLE
fix(simulator): typo on env variable name 

### DIFF
--- a/packages/@prototype/simulator/src/ECSContainerStack/index.ts
+++ b/packages/@prototype/simulator/src/ECSContainerStack/index.ts
@@ -147,7 +147,7 @@ export class ECSContainerStack extends Construct {
 			...props,
 			additionalENVs: {
 				ORIGIN_TABLE_NAME: props.originTable.tableName,
-				ORIGN_EXECUTIONID_INDEX: props.originExecutionIdIndex,
+				ORIGIN_EXECUTIONID_INDEX: props.originExecutionIdIndex,
 				ORIGIN_AREA_INDEX: props.originAreaIndex,
 				ORIGIN_PASSWORD: props.originUserPassword,
 				ORIGIN_STATUS_UPDATE_RULE_NAME: props.iotOriginStatusRuleName,


### PR DESCRIPTION


*Issue #, if available:* NA

*Description of changes:*

- fix simulator env name typo `ORIGN_EXECUTIONID_INDEX` => `ORIGIN_EXECUTIONID_INDEX`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
