### PR TITLE
fix(dispatcher): quarkus app is able to create log file

### DIFF
--- a/prototype/dispatch/order-dispatcher/deploy/application.properties
+++ b/prototype/dispatch/order-dispatcher/deploy/application.properties
@@ -41,7 +41,7 @@ quarkus.log.console.color=true
 quarkus.log.console.format=%d{HH:mm:ss.SSS} %-6p[(T%t{id}) %-16M] %s%e%n
 #
 quarkus.log.file.enable=true
-quarkus.log.file.path=logs/dispatcher.log
+quarkus.log.file.path=dispatcher.log
 quarkus.log.file.level=INFO
 quarkus.log.file.rotation.max-file-size=1m
 quarkus.log.file.rotation.file-suffix=.yyyy-MM-dd

--- a/prototype/dispatch/order-dispatcher/src/main/docker/instant/sequential/Dockerfile
+++ b/prototype/dispatch/order-dispatcher/src/main/docker/instant/sequential/Dockerfile
@@ -54,6 +54,9 @@ COPY ./config/instant/sequential/dispatchSolverConfig.xml /app/config/instant/se
 # executables
 COPY ./*.jar /app
 
+RUN chown -R 1001 /app
+WORKDIR /app
+
 EXPOSE 80 8080
 VOLUME [ "/app/config-external" ]
 USER 1001

--- a/prototype/dispatch/order-dispatcher/src/main/docker/instant/sequential/config/application-docker.properties
+++ b/prototype/dispatch/order-dispatcher/src/main/docker/instant/sequential/config/application-docker.properties
@@ -75,7 +75,7 @@ quarkus.log.console.color=false
 quarkus.log.console.format=%d{HH:mm:ss.SSS} %-6p[(T%t{id}) %-16M] %s%e%n
 #
 quarkus.log.file.enable=true
-quarkus.log.file.path=logs/dispatcher.log
+quarkus.log.file.path=dispatcher.log
 quarkus.log.file.level=INFO
 quarkus.log.file.rotation.max-file-size=1m
 quarkus.log.file.rotation.file-suffix=.yyyy-MM-dd

--- a/prototype/dispatch/order-dispatcher/src/main/resources/application.properties
+++ b/prototype/dispatch/order-dispatcher/src/main/resources/application.properties
@@ -74,7 +74,7 @@ quarkus.log.console.color=true
 quarkus.log.console.format=%d{HH:mm:ss.SSS} %-6p[(T%t{id}) %-16M] %s%e%n
 #
 quarkus.log.file.enable=true
-quarkus.log.file.path=logs/dispatcher.log
+quarkus.log.file.path=dispatcher.log
 quarkus.log.file.level=INFO
 quarkus.log.file.rotation.max-file-size=1m
 quarkus.log.file.rotation.file-suffix=.yyyy-MM-dd


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Dispatch ECS service was recycling containers over and over because logger threw an exception that it was not able to create the log file. Permission added in the Dockerfile and simplified logfile path.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
