### PR TITLE
chore(instant-delivery): add in timeouts to long running step functions

### DIFF
--- a/packages/@prototype/instant-delivery-provider/src/DispatchEngineOrchestrator/DispatchEngineOrchestrator/index.ts
+++ b/packages/@prototype/instant-delivery-provider/src/DispatchEngineOrchestrator/DispatchEngineOrchestrator/index.ts
@@ -19,7 +19,7 @@ import { Duration, aws_iam as iam, aws_lambda as lambda, aws_stepfunctions as st
 import { namespaced } from '@aws-play/cdk-core'
 
 export interface DispatchEngineOrchestratorManagerProps {
-  readonly orchestratorHelper: lambda.IFunction
+	readonly orchestratorHelper: lambda.IFunction
 	readonly orderDispatchTimeoutInMinutes: number
 }
 

--- a/packages/@prototype/instant-delivery-provider/src/DispatchEngineOrchestrator/index.ts
+++ b/packages/@prototype/instant-delivery-provider/src/DispatchEngineOrchestrator/index.ts
@@ -57,7 +57,7 @@ export class DispatchEngineOrchestrator extends Construct {
 			iotEndpointAddress,
 		} = props
 
-		const ochestratorHelper = new OrchestratorHelperLambda(this, 'OrchestratorHelperLambda', {
+		const orchestratorHelper = new OrchestratorHelperLambda(this, 'OrchestratorHelperLambda', {
 			dependencies: {
 				instantDeliveryProviderOrders,
 				instantDeliveryProviderLocks,
@@ -75,11 +75,12 @@ export class DispatchEngineOrchestrator extends Construct {
 		})
 
 		const dispatchEngineOrchestratorManager = new DispatchEngineOrchestratorManager(this, 'DispatchEngineOrchestratorManager', {
-			ochestratorHelper,
+			orchestratorHelper,
+			orderDispatchTimeoutInMinutes: instantDeliveryProviderSettings.orderDispatchTimeoutInMinutes as number,
 		})
 
 		const geoClusteringManager = new GeoClusteringManager(this, 'GeoClusteringManager', {
-			ochestratorHelper,
+			orchestratorHelper,
 			dispatchEngineStepFunction: dispatchEngineOrchestratorManager.stepFunction,
 		})
 

--- a/packages/@prototype/instant-delivery-provider/src/DriverEventHandler/SubMinuteExecutionStepFunction/index.ts
+++ b/packages/@prototype/instant-delivery-provider/src/DriverEventHandler/SubMinuteExecutionStepFunction/index.ts
@@ -22,6 +22,7 @@ import { namespaced } from '@aws-play/cdk-core'
 export interface SubMinuteExecutionStepFunctionProps {
   readonly timeoutInSeconds: number
   readonly stepFunctionIntervalInMinutes: number
+	readonly stepFunctionTimeoutInMinutes: number
   readonly targetLambda: lambda.IFunction
 }
 
@@ -33,6 +34,7 @@ export class SubMinuteExecutionStepFunction extends Construct {
 
 		const {
 			stepFunctionIntervalInMinutes,
+			stepFunctionTimeoutInMinutes,
 			timeoutInSeconds,
 			targetLambda,
 		} = props
@@ -122,6 +124,7 @@ export class SubMinuteExecutionStepFunction extends Construct {
 		this.stepFunction = new stepfunctions.StateMachine(this, 'SubminuteLambdaExecution', {
 			stateMachineName: namespaced(this, 'SubminuteLambdaExecution'),
 			definition,
+			timeout: Duration.minutes(stepFunctionTimeoutInMinutes),
 		})
 	}
 }

--- a/packages/@prototype/instant-delivery-provider/src/DriverEventHandler/SubMinuteExecutionStepFunction/index.ts
+++ b/packages/@prototype/instant-delivery-provider/src/DriverEventHandler/SubMinuteExecutionStepFunction/index.ts
@@ -20,10 +20,10 @@ import { Duration, aws_lambda as lambda, aws_stepfunctions as stepfunctions, aws
 import { namespaced } from '@aws-play/cdk-core'
 
 export interface SubMinuteExecutionStepFunctionProps {
-  readonly timeoutInSeconds: number
-  readonly stepFunctionIntervalInMinutes: number
+	readonly timeoutInSeconds: number
+	readonly stepFunctionIntervalInMinutes: number
 	readonly stepFunctionTimeoutInMinutes: number
-  readonly targetLambda: lambda.IFunction
+	readonly targetLambda: lambda.IFunction
 }
 
 export class SubMinuteExecutionStepFunction extends Construct {

--- a/packages/@prototype/instant-delivery-provider/src/DriverEventHandler/index.ts
+++ b/packages/@prototype/instant-delivery-provider/src/DriverEventHandler/index.ts
@@ -91,6 +91,7 @@ export class DriverEventHandler extends Construct {
 			targetLambda: this.driverCleanupFunction,
 			timeoutInSeconds: instantDeliveryProviderSettings.driverCleanupIntervalInSeconds as number,
 			stepFunctionIntervalInMinutes: instantDeliveryProviderSettings.subMinuteStepFunctionIntervalInMinutes as number,
+			stepFunctionTimeoutInMinutes: instantDeliveryProviderSettings.subMinuteStepFunctionTimeoutInMinutes as number,
 		})
 
 		new events.Rule(this, 'InstantDeliveryProviderCleanupFunction', {

--- a/packages/@prototype/order-manager/src/OrderManager/OrderManagerStepFunction/index.ts
+++ b/packages/@prototype/order-manager/src/OrderManager/OrderManagerStepFunction/index.ts
@@ -286,6 +286,7 @@ export class OrderManagerStepFunction extends Construct {
 			stateMachineName: namespaced(this, 'OrderManagerStepFunction'),
 			definition,
 			role: stepFunctionRole,
+			timeout: Duration.minutes(orderManagerSettings.orderTimeoutInMinutes as number),
 		})
 	}
 }

--- a/prototype/infra/config/default.yaml
+++ b/prototype/infra/config/default.yaml
@@ -71,7 +71,7 @@ memoryDBConfig:
   instanceType: db.r6g.xlarge
 
   # number of shards
-  numShards: 3
+  numShards: 1
 
   # number of read replicas per shard
   numReplicasPerShard: 2
@@ -228,6 +228,11 @@ orderManagerSettings:
   # if a reject/accept event doesn't come by then, the order will be automaticall rejected
   originTimeoutInMinutes: 5
 
+  # timeout for the order execution. if the order has not been 
+  # elaborate within this timeout the execution would be aborted. 
+  # default: 5 hours
+  orderTimeoutInMinutes: 300
+
 # settigns for the example instant delivery provider implementation
 instantDeliveryProviderSettings:
   # shard count for the order batch stream
@@ -260,8 +265,15 @@ instantDeliveryProviderSettings:
   # interval in mins for subMinuteStepFunction helper
   subMinuteStepFunctionIntervalInMinutes: 10
 
+  # subMinuteStepFunction timeout
+  subMinuteStepFunctionTimeoutInMinutes: 12
+
   # cancel orders after XX seconds if not assigned
   orderCancellationTimeoutInSeconds: 1500
+
+  # define the max timeout for dispatching orders to drivers
+  # executions that take longer than this will be aborted
+  orderDispatchTimeoutInMinutes: 30
 
   # bias for geocluster algo
   # see https://github.com/yetzt/node-geocluster


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:*

- setup Redis cluster mode with one shard
- define order manager step functions timeout
- define instant delivery step functions timeout
- rename property spelled wrongly inside the instant delivery provider



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
