### PR TITLE
chore(infra): add ecs task count as configuration parameter

### DIFF
--- a/packages/@prototype/dispatch-setup/src/DispatchSetup/DispatchEcsService/index.ts
+++ b/packages/@prototype/dispatch-setup/src/DispatchSetup/DispatchEcsService/index.ts
@@ -33,6 +33,7 @@ export interface DispatchEcsServiceProps {
 	readonly dispatcherAssignmentsTable: ddb.ITable
 	readonly osmPbfMapFileUrl: string
 	readonly containerName: string
+	readonly ecsTaskCount: number
 }
 
 export class DispatchEcsService extends Construct {
@@ -53,6 +54,7 @@ export class DispatchEcsService extends Construct {
 			dispatcherAssignmentsTable,
 			osmPbfMapFileUrl,
 			containerName,
+			ecsTaskCount,
 		} = props
 
 		const driverApiKeySecret = secretsmanager.Secret.fromSecretNameV2(this, 'DriverApiKeySecret', driverApiKeySecretName)
@@ -155,7 +157,7 @@ export class DispatchEcsService extends Construct {
 
 		const dispatcherService = new ecs.Ec2Service(this, 'DispatcherService', {
 			cluster: ecsCluster,
-			desiredCount: 10,
+			desiredCount: ecsTaskCount,
 			securityGroups: [dmzSecurityGroup],
 			serviceName: namespaced(this, 'Order-Dispatcher'),
 			taskDefinition: dispatcherTask,

--- a/packages/@prototype/dispatch-setup/src/DispatchSetup/index.ts
+++ b/packages/@prototype/dispatch-setup/src/DispatchSetup/index.ts
@@ -21,17 +21,18 @@ import { DispatchEcsService } from './DispatchEcsService'
 import { DispatchEcsCluster } from './DispatchEcsCluster'
 
 export interface DispatchSetupProps {
-    readonly vpc: ec2.IVpc
-    readonly dmzSecurityGroup: ec2.ISecurityGroup
-    readonly driverApiUrl: string
-    readonly driverApiKeySecretName: string
-    readonly dispatchEngineBucket: s3.IBucket
-    readonly dispatcherConfigPath: string
-    readonly dispatcherVersion: string
+	readonly vpc: ec2.IVpc
+	readonly dmzSecurityGroup: ec2.ISecurityGroup
+	readonly driverApiUrl: string
+	readonly driverApiKeySecretName: string
+	readonly dispatchEngineBucket: s3.IBucket
+	readonly dispatcherConfigPath: string
+	readonly dispatcherVersion: string
 	readonly dispatcherDockerOsmPbfMapFileUrl: string
 	readonly dispatcherDockerContainerName: string
 	readonly demAreaDispatchEngineSettingsTable: ddb.ITable
 	readonly dispatcherAssignmentsTable: ddb.ITable
+	readonly dispatcherSettings: Record<string, string | number>
 }
 
 export class DispatchSetup extends Construct {
@@ -54,6 +55,7 @@ export class DispatchSetup extends Construct {
 			dispatcherDockerOsmPbfMapFileUrl,
 			demAreaDispatchEngineSettingsTable,
 			dispatcherAssignmentsTable,
+			dispatcherSettings,
 		} = props
 
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -84,6 +86,7 @@ export class DispatchSetup extends Construct {
 			osmPbfMapFileUrl: dispatcherDockerOsmPbfMapFileUrl,
 			demAreaDispatchEngineSettingsTable,
 			dispatcherAssignmentsTable,
+			ecsTaskCount: dispatcherSettings.ecsTaskCount as number,
 		})
 
 		this.loadBalancer = dispatchEcsService.loadBalancer

--- a/packages/@prototype/dispatch-setup/src/GraphhopperSetup/index.ts
+++ b/packages/@prototype/dispatch-setup/src/GraphhopperSetup/index.ts
@@ -28,6 +28,7 @@ export interface GraphhopperSetupProps {
 	readonly osmPbfMapFileUrl: string
 	readonly javaOpts?: string
 	readonly containerName: string
+	readonly ecsTaskCount: number
 }
 
 export class GraphhopperSetup extends Construct {
@@ -43,6 +44,7 @@ export class GraphhopperSetup extends Construct {
 			osmPbfMapFileUrl,
 			javaOpts,
 			containerName,
+			ecsTaskCount,
 		} = props
 
 		const graphhopperImage = new ecr_assets.DockerImageAsset(this, 'GraphhopperDockerImage', {
@@ -81,7 +83,7 @@ export class GraphhopperSetup extends Construct {
 
 		const graphhopperService = new ecs.FargateService(this, 'GraphhopperService', {
 			cluster: ecsCluster,
-			desiredCount: 4,
+			desiredCount: ecsTaskCount,
 			securityGroups: [dmzSecurityGroup],
 			serviceName: namespaced(this, 'Graphhopper-Indonesia'),
 			taskDefinition: graphhopperTask,

--- a/prototype/infra/config/default.yaml
+++ b/prototype/infra/config/default.yaml
@@ -285,14 +285,20 @@ graphhopperSettings:
   # graphhopper docker image along with the pre-generated gh-cache
   osmPbfMapFileUrl: https://download.geofabrik.de/asia/indonesia-latest.osm.pbf
 
+  # desired amount of ECS tasks that run in parallel to serve requests to graph hopper
+  ecsTaskCount: 4
+
   # optional JAVA_OPTS
   # javaOpts: -Xmx6g -Xms6g -Ddw.server.application_connectors[0].bind_host=0.0.0.0 -Ddw.server.application_connectors[0].port=80
 
   # name for graphhopper docker repo
   containerName: graphhopper-indonesia
 
-# name for dispatcher app docker repo
-dispatcherAppDockerRepoName: order-dispatcher
+# settings for the dispatcher app
+dispatcherSettings:
+  # desired amount of ECS tasks that run in parallel to serve requests to the dispatcher
+  ecsTaskCount: 2
+
 
 # country to configure the simulator for. Allowed values: Philippines and Indonesia
 # default: Indonesia

--- a/prototype/infra/lib/stack/nested/DispatcherStack/index.ts
+++ b/prototype/infra/lib/stack/nested/DispatcherStack/index.ts
@@ -32,6 +32,7 @@ export interface DispatcherStackProps extends NestedStackProps {
 	readonly dispatcherDockerContainerName: string
 	readonly demAreaDispatchEngineSettingsTable: ddb.ITable
 	readonly dispatcherAssignmentsTable: ddb.ITable
+	readonly dispatcherSettings: Record<string, string | number>
 }
 
 export class DispatcherStack extends NestedStack {
@@ -56,6 +57,7 @@ export class DispatcherStack extends NestedStack {
 			dispatcherDockerOsmPbfMapFileUrl,
 			demAreaDispatchEngineSettingsTable,
 			dispatcherAssignmentsTable,
+			dispatcherSettings,
 		} = props
 
 		const dispatchSetup = new DispatchSetup(this, 'DispatchSetup', {
@@ -70,6 +72,7 @@ export class DispatcherStack extends NestedStack {
 			dispatcherAssignmentsTable,
 			dispatcherDockerContainerName,
 			dispatcherDockerOsmPbfMapFileUrl,
+			dispatcherSettings,
 		})
 
 		this.dispatcherLB = dispatchSetup.loadBalancer

--- a/prototype/infra/lib/stack/nested/ProviderStack/index.ts
+++ b/prototype/infra/lib/stack/nested/ProviderStack/index.ts
@@ -42,7 +42,7 @@ export interface ProviderStackProps extends NestedStackProps {
 	readonly instantDeliveryProviderOrdersStatusIndex: string
 	readonly dispatchEngineLB: elb.IApplicationLoadBalancer
 	readonly backendEcsCluster: ecs.ICluster
-	readonly graphhopperSettings: Record<string, string>
+	readonly graphhopperSettings: Record<string, string | number>
 	readonly iotEndpointAddress: string
 }
 
@@ -119,9 +119,10 @@ export class ProviderStack extends NestedStack {
 			vpc,
 			dmzSecurityGroup: securityGroups.dmz,
 			ecsCluster: backendEcsCluster,
-			osmPbfMapFileUrl: graphhopperSettings.osmPbfMapFileUrl,
-			javaOpts: graphhopperSettings.javaOpts,
-			containerName: graphhopperSettings.containerName,
+			osmPbfMapFileUrl: graphhopperSettings.osmPbfMapFileUrl.toString(),
+			javaOpts: graphhopperSettings.javaOpts.toString(),
+			containerName: graphhopperSettings.containerName.toString(),
+			ecsTaskCount: graphhopperSettings.ecsTaskCount as number,
 		})
 
 		const graphhopperLB = graphhopperSetup.loadBalancer

--- a/prototype/infra/lib/stack/root/BackendStack/index.ts
+++ b/prototype/infra/lib/stack/root/BackendStack/index.ts
@@ -48,8 +48,8 @@ export interface BackendStackProps extends StackProps {
 	readonly instantDeliveryProviderSettings: { [key: string]: string | number | boolean, }
 	readonly orderManagerSettings: { [key: string]: string | number | boolean, }
 	readonly geoTrackingApiKeySecretName: string
-	readonly graphhopperSettings: Record<string, string>
-	readonly dispatcherAppDockerRepoName: string
+	readonly graphhopperSettings: Record<string, string | number>
+	readonly dispatcherSettings: Record<string, string | number>
 }
 
 /**
@@ -108,7 +108,7 @@ export class BackendStack extends Stack {
 			geoTrackingApiKeySecretName,
 			orderManagerSettings,
 			graphhopperSettings,
-			dispatcherAppDockerRepoName,
+			dispatcherSettings,
 		} = props
 
 		setNamespace(this, namespace)
@@ -177,7 +177,8 @@ export class BackendStack extends Stack {
 			demAreaDispatchEngineSettingsTable: demographicAreaDispatchSettings,
 			dispatcherAssignmentsTable,
 			dispatcherDockerContainerName: 'order-dispatcher',
-			dispatcherDockerOsmPbfMapFileUrl: graphhopperSettings.osmPbfMapFileUrl,
+			dispatcherDockerOsmPbfMapFileUrl: graphhopperSettings.osmPbfMapFileUrl.toString(),
+			dispatcherSettings,
 		})
 
 		const providerNestedStack = new ProviderStack(this, 'ProvidersNestedStack', {


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:*

- add ability to configure ECS Task count for both Graph Hopper and Dispatch Engine


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
