### PR TITLE
fix(dispatch/infra): ssm parameters passed around as objects instead of string keys

### DIFF
--- a/packages/@prototype/dispatch-setup/src/DispatchSetup/DispatchHosting/index.ts
+++ b/packages/@prototype/dispatch-setup/src/DispatchSetup/DispatchHosting/index.ts
@@ -24,7 +24,7 @@ import { namespaced } from '@aws-play/cdk-core'
 export interface DispatchHostingProps {
 	readonly dispatchEngineBucket: s3.IBucket
 	readonly driverApiKeySecretName: string
-	readonly driverApiUrlParameterName: string
+	// readonly driverApiUrlParameterName: string
 	readonly dispatcherConfigPath: string
 	readonly dispatcherVersion: string
 	readonly demographicAreaDispatcherSettingsTableName: string
@@ -39,7 +39,7 @@ export class DispatchHosting extends Construct {
 			dispatchEngineBucket,
 			dispatcherConfigPath,
 			driverApiKeySecretName,
-			driverApiUrlParameterName,
+			// driverApiUrlParameterName,
 			dispatcherVersion,
 			demographicAreaDispatcherSettingsTableName,
 			dispatcherAssignmentTableName,
@@ -50,7 +50,7 @@ export class DispatchHosting extends Construct {
 		const applicationPropsContent = fs.readFileSync(applicationsPropsPath, { encoding: 'utf-8' })
 		const renderedContent = render(applicationPropsContent, {
 			dispatchEngineBucketName: dispatchEngineBucket.bucketName,
-			driverApiUrlParameterName,
+			// driverApiUrlParameterName,
 			driverApiKeySecretName,
 			dispatcherVersion,
 			demographicAreaDispatcherSettingsTableName,

--- a/packages/@prototype/dispatch-setup/src/DispatchSetup/index.ts
+++ b/packages/@prototype/dispatch-setup/src/DispatchSetup/index.ts
@@ -15,7 +15,7 @@
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
 import { Construct } from 'constructs'
-import { aws_dynamodb as ddb, aws_ec2 as ec2, aws_ecs as ecs, aws_elasticloadbalancingv2 as elb, aws_s3 as s3 } from 'aws-cdk-lib'
+import { aws_dynamodb as ddb, aws_ec2 as ec2, aws_ecs as ecs, aws_elasticloadbalancingv2 as elb, aws_s3 as s3, aws_ssm as ssm } from 'aws-cdk-lib'
 import { DispatchHosting } from './DispatchHosting'
 import { DispatchEcsService } from './DispatchEcsService'
 import { DispatchEcsCluster } from './DispatchEcsCluster'
@@ -23,7 +23,7 @@ import { DispatchEcsCluster } from './DispatchEcsCluster'
 export interface DispatchSetupProps {
     readonly vpc: ec2.IVpc
     readonly dmzSecurityGroup: ec2.ISecurityGroup
-	readonly parameterStoreKeys: Record<string, string>
+	readonly ssmStringParameters: Record<string, ssm.IStringParameter>
     readonly driverApiKeySecretName: string
     readonly dispatchEngineBucket: s3.IBucket
     readonly dispatcherConfigPath: string
@@ -47,7 +47,7 @@ export class DispatchSetup extends Construct {
 			vpc,
 			dmzSecurityGroup,
 			driverApiKeySecretName,
-			parameterStoreKeys,
+			ssmStringParameters,
 			dispatchEngineBucket,
 			dispatcherConfigPath,
 			dispatcherVersion,
@@ -63,7 +63,7 @@ export class DispatchSetup extends Construct {
 		const dispatchHosting = new DispatchHosting(this, 'DispatchHosting', {
 			dispatchEngineBucket,
 			driverApiKeySecretName,
-			driverApiUrlParameterName: parameterStoreKeys.geoTrackingApiUrl,
+			// driverApiUrlParameterName: ssmStringParameters[geoTrackingApiUrl].stringValue,
 			dispatcherConfigPath,
 			dispatcherVersion,
 			dispatcherAssignmentTableName: dispatcherAssignmentsTable.tableName,
@@ -83,7 +83,7 @@ export class DispatchSetup extends Construct {
 			ecsCluster: dispatchEcsCluster.cluster,
 			dispatchEngineBucket,
 			driverApiKeySecretName,
-			parameterStoreKeys,
+			ssmStringParameters,
 			containerName: dispatcherDockerContainerName,
 			osmPbfMapFileUrl: dispatcherDockerOsmPbfMapFileUrl,
 			demAreaDispatchEngineSettingsTable,

--- a/prototype/dispatch/delivery-dispatch/apps/instant-sequential/src/main/docker/Dockerfile
+++ b/prototype/dispatch/delivery-dispatch/apps/instant-sequential/src/main/docker/Dockerfile
@@ -48,7 +48,7 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 
 # mapfile
-COPY --from=downloader /download/mapfile.osm.pbf /map/mapfile.osm.pbf
+COPY --from=downloader --chown=1001 /download/mapfile.osm.pbf /map/mapfile.osm.pbf
 
 # graphhopper cache
 COPY --from=gh-build --chown=1001 /graphhopper-cache /graphhopper-cache

--- a/prototype/infra/lib/stack/nested/DispatcherStack/index.ts
+++ b/prototype/infra/lib/stack/nested/DispatcherStack/index.ts
@@ -16,7 +16,7 @@
  *********************************************************************************************************************/
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { Construct } from 'constructs'
-import { NestedStack, NestedStackProps, aws_s3 as s3, aws_ec2 as ec2, aws_elasticloadbalancingv2 as elb, aws_dynamodb as ddb, aws_ecs as ecs } from 'aws-cdk-lib'
+import { NestedStack, NestedStackProps, aws_s3 as s3, aws_ec2 as ec2, aws_elasticloadbalancingv2 as elb, aws_dynamodb as ddb, aws_ssm as ssm } from 'aws-cdk-lib'
 import { Networking } from '@prototype/networking'
 import { DispatchSetup, GraphhopperSetup } from '@prototype/dispatch-setup'
 
@@ -24,7 +24,7 @@ export interface DispatcherStackProps extends NestedStackProps {
 	readonly vpc: ec2.IVpc
 	readonly vpcNetworking: Networking
 	readonly driverApiKeySecretName: string
-	readonly parameterStoreKeys: Record<string, string>
+	readonly ssmStringParameters: Record<string, ssm.IStringParameter>
 	readonly dispatchEngineBucket: s3.IBucket
 	readonly dispatcherConfigPath: string
 	readonly dispatcherVersion: string
@@ -50,7 +50,7 @@ export class DispatcherStack extends NestedStack {
 			},
 			dispatchEngineBucket,
 			driverApiKeySecretName,
-			parameterStoreKeys,
+			ssmStringParameters,
 			dispatcherConfigPath,
 			dispatcherVersion,
 			dispatcherDockerContainerName,
@@ -67,7 +67,7 @@ export class DispatcherStack extends NestedStack {
 			dispatcherConfigPath,
 			dispatcherVersion,
 			driverApiKeySecretName,
-			parameterStoreKeys,
+			ssmStringParameters,
 			demAreaDispatchEngineSettingsTable,
 			dispatcherAssignmentsTable,
 			dispatcherDockerContainerName,

--- a/prototype/infra/lib/stack/nested/MicroServiceStack/index.ts
+++ b/prototype/infra/lib/stack/nested/MicroServiceStack/index.ts
@@ -55,6 +55,8 @@ export class MicroServiceStack extends NestedStack {
 
 	public readonly lambdaLayers: { [key: string]: lambda.ILayerVersion, }
 
+	public readonly ssmStringParameters: Record<string, ssm.IStringParameter>
+
 	constructor (scope: Construct, id: string, props: MicroServiceStackProps) {
 		super(scope, id, props)
 
@@ -149,6 +151,9 @@ export class MicroServiceStack extends NestedStack {
 			parameterName: geoTrackingApiUrlParameterName,
 			stringValue: geoTrackingRestApi.url,
 		})
+
+		this.ssmStringParameters = {}
+		this.ssmStringParameters[geoTrackingApiUrlParameterName] = geoTrackingApiUrlStringParameter
 
 		const apiGeofencing = new ApiGeofencing(this, 'ApiGeofencing', {
 			restApi: geoTrackingRestApi,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixing deployment bug for SSM parameters for dispatcher.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
