### PR TITLE
fix(web): fix wrong labels on EntitySimulationSummary

### DIFF
--- a/prototype/simulator/website/src/components/EntitySimulationSummary/index.tsx
+++ b/prototype/simulator/website/src/components/EntitySimulationSummary/index.tsx
@@ -47,6 +47,7 @@ export type ISimulation = {
 export type EntitySimulationSummaryProps = {
   simulation: ISimulation
 	extraProps?: string[]
+	entityName: string
   onStop?: (simulation: ISimulation) => void
 }
 
@@ -54,7 +55,12 @@ const mapTasksWithArn = (taskArnPrefix: string, tasks: string[]) => {
 	return (tasks || []).map(q => `${taskArnPrefix}/${q}`)
 }
 
-const EntitySimulationSummary: React.FC<EntitySimulationSummaryProps> = ({ simulation, onStop, extraProps = [] }) => {
+const EntitySimulationSummary: React.FC<EntitySimulationSummaryProps> = ({
+	entityName,
+	simulation,
+	onStop,
+	extraProps = [],
+}) => {
 	return (
 		<Container
 			key={simulation.ID}
@@ -83,7 +89,7 @@ const EntitySimulationSummary: React.FC<EntitySimulationSummaryProps> = ({ simul
 						<Heading variant='h3'>Simulation Setup</Heading>
 					</Box>
 					<EntityDetailsTableComponent
-						entityName={'Origins (eg. restaurants)'}
+						entityName={entityName}
 						entities={simulation.stats}
 						renderActions={false}
 						renderState={false}

--- a/prototype/simulator/website/src/pages/Destinations/index.tsx
+++ b/prototype/simulator/website/src/pages/Destinations/index.tsx
@@ -143,6 +143,7 @@ const Destinations: React.FC = () => {
 					simulation={sim}
 					onStop={stopSimulation}
 					extraProps={['rejectionRate', 'orderRate', 'orderInterval', 'eventsFilePath']}
+					entityName='Destinations'
 				/>
 			</>))}
 			<DestinationAdditionalInputs

--- a/prototype/simulator/website/src/pages/Origins/index.tsx
+++ b/prototype/simulator/website/src/pages/Origins/index.tsx
@@ -143,6 +143,7 @@ const Origins: React.FC = () => {
 					simulation={sim}
 					onStop={stopSimulation}
 					extraProps={['rejectionRate']}
+					entityName='Origins'
 				/>
 			</>))}
 			<OriginAdditionalInputs


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:*

- fix the common `EntitySimulationSummary` component to accept an `entityName` property to use as label


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
