### PR TITLE
fix(geotracking): fix while loop condition in QueryDrivers lambda 

### DIFF
--- a/packages/@prototype/api-geotracking/src/ApiGeotracking/QueryDrivers/@lambda/index.js
+++ b/packages/@prototype/api-geotracking/src/ApiGeotracking/QueryDrivers/@lambda/index.js
@@ -24,6 +24,7 @@ const SHAPES = {
 	CIRCLE: 'circle',
 	BOX: 'box',
 }
+const MAX_ITERATIONS = 5
 
 const handler = async (event) => {
 	switch (event.httpMethod) {
@@ -166,17 +167,14 @@ const handlePOST = async (event) => {
 				driversPerLocation = driversPerLocation.map(d => ({ distance: distByDriverId[d.driverId], distanceUnit, ...d }))
 
 				iteration++
-			} while (driversPerLocation.length < elements.length) // countPerLocation)
+			} while (driversPerLocation.length < elements.length && iteration <= MAX_ITERATIONS)
 
-			// driversPerLocation.slice(0, countPerLocation).forEach(d => {
 			driversPerLocation.forEach(d => {
 				driversById[d.driverId] = d
 			})
 		}
 
-		const drivers = Object.values(driversById)
-
-		return success(drivers)
+		return success(Object.values(driversById))
 	} catch (err) {
 		console.error('Error while querying drivers: ', err)
 


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:*

- fix while loop condition in `QueryDrivers` lambda to avoid infinite loop when drivers are missing from the system (either no IDLE drivers are available or no drivers are logged in)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
