### PR TITLE
fix(ssd-infra): fix resources name to avoid error during deployment

### DIFF
--- a/packages/@prototype/dispatch-setup/src/DispatchSetup/SameDayDispatchEcsService/index.ts
+++ b/packages/@prototype/dispatch-setup/src/DispatchSetup/SameDayDispatchEcsService/index.ts
@@ -91,7 +91,7 @@ export class SameDayDispatchEcsService extends Construct {
 					],
 				}),
 			},
-			roleName: regionalNamespaced(this, 'Dispatcher-SameDayDeliveryDirectPudo-TaskRole'),
+			roleName: regionalNamespaced(this, 'Dispatcher-SDDDirectPudo-TaskRole'),
 		})
 
 		const dispatcherTask = new ecs.Ec2TaskDefinition(this, 'SameDayDeliveryDirectPudoDispatcherTaskDef', {
@@ -163,7 +163,7 @@ export class SameDayDispatchEcsService extends Construct {
 			vpc,
 			internetFacing: false,
 			securityGroup: dmzSecurityGroup,
-			loadBalancerName: namespaced(this, 'Dispatcher-SameDay-DirectPudo'),
+			loadBalancerName: namespaced(this, 'Dispatcher-SDD-ALB'),
 			vpcSubnets: { subnetType: ec2.SubnetType.PUBLIC },
 		})
 		new DefaultWaf(this, 'Dispatcher-SameDayDirectPudo-ALB-Waf', {
@@ -181,7 +181,7 @@ export class SameDayDispatchEcsService extends Construct {
 		albListener.addTargets('Dispatch-SameDayDirectPudo-Target', {
 			port: dispatchConfig.hostPort as number || 8080,
 			targets: [dispatcherService],
-			targetGroupName: namespaced(this, 'dispatcher-sameday-directpudo-targetgroup'),
+			targetGroupName: namespaced(this, 'dispatcher-SDD-TG'),
 			protocol: elb.ApplicationProtocol.HTTP,
 			healthCheck: {
 				path: '/q/health',


### PR DESCRIPTION
*Issue #, if available:* NA

to fix errors as:

```
1 validation error detected: Value 'devproto-Dispatcher-SameDayDeliveryDirectPudo-TaskRole-ap-southeast-1' at 'roleName' failed to satisfy constraint: Member must have length less than or equal to 64 (Service: AmazonIdentityManagement; Status Code: 400; Error Code: ValidationError)
```

*Description of changes:* 

- update resources name to avoid deployment errors due to length limitations on some services 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
