### PR TITLE
fix(instant-delivery): update routing details information to include unit/value

### DIFF
--- a/packages/@prototype/instant-delivery-provider/src/DispatchEngineOrchestrator/OrchestratorHelperLambda/@lambda/src/lib/routing.js
+++ b/packages/@prototype/instant-delivery-provider/src/DispatchEngineOrchestrator/OrchestratorHelperLambda/@lambda/src/lib/routing.js
@@ -32,8 +32,14 @@ const queryGraphHopper = async (points) => {
 	const { distance, time, points: pointsEncoded } = paths[0]
 
 	return {
-		distance,
-		time,
+		distance: {
+			value: distance,
+			unit: 'm',
+		},
+		time: {
+			value: time / 1000,
+			unit: 'sec',
+		},
 		pointsEncoded,
 	}
 }


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:*

- update the graph hopper routing object returned for instant delivery to include distance/time as object with their respective value/unit represented explicitly

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
