### PR TITLE
fix(infra): remove managed policies where they are not needed

### DIFF
--- a/packages/@aws-play/cdk-apigateway/src/RestApi/index.ts
+++ b/packages/@aws-play/cdk-apigateway/src/RestApi/index.ts
@@ -17,11 +17,9 @@
 import { Construct } from 'constructs'
 import {
 	aws_apigateway as apigw,
-	aws_iam as iam,
 	aws_lambda as lambda,
 	aws_lambda_nodejs as lambda_nodejs,
 } from 'aws-cdk-lib'
-import { ServicePrincipals, ManagedPolicies } from 'cdk-constants'
 import { namespaced, uniqueIdHash } from '@aws-play/cdk-core'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -99,78 +97,10 @@ export class RestApi extends apigw.RestApi {
 		return cognitoAuthorizer
 	}
 
-	// helper for add*FunctionToResource
-	private createDefaultLambdaRole (id: string, functionName: string): iam.Role {
-		return new iam.Role(this, `${id}-role-${uniqueIdHash(this)}`, {
-			assumedBy: new iam.ServicePrincipal(ServicePrincipals.LAMBDA),
-			description: `Execution role for ${functionName}`,
-			managedPolicies: [iam.ManagedPolicy.fromAwsManagedPolicyName(ManagedPolicies.AWS_LAMBDA_EXECUTE)],
-			roleName: namespaced(this, functionName),
-		})
-	}
-
-	private createFunctionToResource<TProps extends lambda.FunctionProps | lambda_nodejs.NodejsFunctionProps> (
-		resource: apigw.IResource,
-		props: CreateFunctionToResourceProps,
-		FnType: {
-      new (scope: Construct, id: string, fnProps: TProps): lambda.IFunction
-    },
-	): lambda.IFunction {
-		const { httpMethod, functionId, functionProps, methodOptions } = props
-
-		const { functionName, role } = functionProps
-
-		if (functionName === undefined) {
-			throw new Error('You need to provide a functionName property')
-		}
-
-		let lambdaExecutionRole
-
-		if (role === undefined) {
-			lambdaExecutionRole = this.createDefaultLambdaRole(functionId, functionName)
-		}
-
-		const lambdaFunctionProps = {
-			...(functionProps as TProps),
-			role: role || lambdaExecutionRole,
-			functionName: namespaced(this, functionName),
-		}
-
-		const lambdaFunction = new FnType(this, `${functionId}-fn-${uniqueIdHash(this)}`, lambdaFunctionProps)
-
-		this.addFunctionToResource(resource, {
-			httpMethod,
-			methodOptions,
-			function: lambdaFunction,
-		})
-
-		return lambdaFunction
-	}
-
 	addFunctionToResource (resource: apigw.IResource, props: AddFunctionToResourceProps): void {
 		const { httpMethod, methodOptions, function: lambdaFunction } = props
 
 		const lambdaIntegration = new apigw.LambdaIntegration(lambdaFunction)
 		resource.addMethod(httpMethod, lambdaIntegration, methodOptions)
-	}
-
-	createLambdaFunctionToResource (resource: apigw.IResource, props: CreateFunctionToResourceProps): lambda.IFunction {
-		const { functionProps } = props
-
-		if ((functionProps as lambda.FunctionProps) === undefined) {
-			throw new Error('functionProps must be of type FunctionProps')
-		}
-
-		return this.createFunctionToResource(resource, props, lambda.Function)
-	}
-
-	createNodejsFunctionToResource (resource: apigw.IResource, props: CreateFunctionToResourceProps): lambda.IFunction {
-		const { functionProps } = props
-
-		if ((functionProps as lambda_nodejs.NodejsFunctionProps) === undefined) {
-			throw new Error('functionProps must be of type NodejsFunctionProps')
-		}
-
-		return this.createFunctionToResource(resource, props, lambda_nodejs.NodejsFunction)
 	}
 }

--- a/packages/@prototype/api-geotracking/src/ApiGeofencing/GeofencingService/index.ts
+++ b/packages/@prototype/api-geotracking/src/ApiGeofencing/GeofencingService/index.ts
@@ -19,7 +19,7 @@ import { Duration, aws_lambda as lambda, aws_iam as iam, aws_events as events, a
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
 import { MemoryDBCluster } from '@prototype/live-data-cache'
 import { namespaced } from '@aws-play/cdk-core'
-import { LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
+import { LambdaInsightsExecutionPolicyStatements } from '@prototype/lambda-common'
 import { SERVICE_NAME } from '@prototype/common'
 
 interface Environment extends DeclaredLambdaEnvironment {
@@ -81,6 +81,7 @@ export class GeofencingServiceLambda extends DeclaredLambdaFunction<Environment,
 						`${memoryDBCluster.adminPasswordSecret.secretArn}*`,
 					],
 				}),
+				...LambdaInsightsExecutionPolicyStatements(),
 			],
 			vpc,
 			vpcSubnets: {
@@ -90,9 +91,5 @@ export class GeofencingServiceLambda extends DeclaredLambdaFunction<Environment,
 		}
 
 		super(scope, id, declaredProps)
-
-		if (this.role) {
-			this.role.addManagedPolicy(LambdaInsightsExecutionPolicy())
-		}
 	}
 }

--- a/packages/@prototype/api-geotracking/src/ApiGeotracking/GetDemAreaSettings/index.ts
+++ b/packages/@prototype/api-geotracking/src/ApiGeotracking/GetDemAreaSettings/index.ts
@@ -18,7 +18,7 @@ import { Construct } from 'constructs'
 import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_memorydb as memorydb, aws_dynamodb as ddb } from 'aws-cdk-lib'
 import { namespaced } from '@aws-play/cdk-core'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
-import { LambdaInsightsExecutionPolicy, readDDBTablePolicyStatement } from '@prototype/lambda-common'
+import { LambdaInsightsExecutionPolicyStatements, readDDBTablePolicyStatement } from '@prototype/lambda-common'
 
 interface Environment extends DeclaredLambdaEnvironment {
     readonly DDB_TABLE: string
@@ -55,6 +55,7 @@ export class GetDemAreaSettingsLambda extends DeclaredLambdaFunction<Environment
 			layers: lambdaLayers,
 			initialPolicy: [
 				readDDBTablePolicyStatement(demographicAreaDispatchSettings.tableArn),
+				...LambdaInsightsExecutionPolicyStatements(),
 			],
 			vpc,
 			vpcSubnets: {
@@ -64,9 +65,5 @@ export class GetDemAreaSettingsLambda extends DeclaredLambdaFunction<Environment
 		}
 
 		super(scope, id, declaredProps)
-
-		if (this.role) {
-			this.role.addManagedPolicy(LambdaInsightsExecutionPolicy())
-		}
 	}
 }

--- a/packages/@prototype/api-geotracking/src/ApiGeotracking/GetDriverLocation/index.ts
+++ b/packages/@prototype/api-geotracking/src/ApiGeotracking/GetDriverLocation/index.ts
@@ -19,7 +19,7 @@ import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_iam as iam } from '
 import { MemoryDBCluster } from '@prototype/live-data-cache'
 import { namespaced } from '@aws-play/cdk-core'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
-import { LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
+import { LambdaInsightsExecutionPolicyStatements } from '@prototype/lambda-common'
 
 interface Environment extends DeclaredLambdaEnvironment {
 	readonly MEMORYDB_ADMIN_USERNAME: string
@@ -69,6 +69,7 @@ export class GetDriverLocationLambda extends DeclaredLambdaFunction<Environment,
 						`${memoryDBCluster.adminPasswordSecret.secretArn}*`,
 					],
 				}),
+				...LambdaInsightsExecutionPolicyStatements(),
 			],
 			vpc,
 			vpcSubnets: {
@@ -78,9 +79,5 @@ export class GetDriverLocationLambda extends DeclaredLambdaFunction<Environment,
 		}
 
 		super(scope, id, declaredProps)
-
-		if (this.role) {
-			this.role.addManagedPolicy(LambdaInsightsExecutionPolicy())
-		}
 	}
 }

--- a/packages/@prototype/api-geotracking/src/ApiGeotracking/ListDriversForPolygon/index.ts
+++ b/packages/@prototype/api-geotracking/src/ApiGeotracking/ListDriversForPolygon/index.ts
@@ -19,7 +19,7 @@ import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_dynamodb as ddb, aw
 import { MemoryDBCluster } from '@prototype/live-data-cache'
 import { namespaced } from '@aws-play/cdk-core'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
-import { AllowOpenSearchRead, AllowOpenSearchWrite, readDDBTablePolicyStatement, LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
+import { AllowOpenSearchRead, AllowOpenSearchWrite, readDDBTablePolicyStatement, LambdaInsightsExecutionPolicyStatements } from '@prototype/lambda-common'
 
 interface Environment extends DeclaredLambdaEnvironment {
 	readonly MEMORYDB_ADMIN_USERNAME: string
@@ -80,6 +80,7 @@ export class ListDriversForPolygonLambda extends DeclaredLambdaFunction<Environm
 						`${memoryDBCluster.adminPasswordSecret.secretArn}*`,
 					],
 				}),
+				...LambdaInsightsExecutionPolicyStatements(),
 			],
 			vpc,
 			vpcSubnets: {
@@ -89,9 +90,5 @@ export class ListDriversForPolygonLambda extends DeclaredLambdaFunction<Environm
 		}
 
 		super(scope, id, declaredProps)
-
-		if (this.role) {
-			this.role.addManagedPolicy(LambdaInsightsExecutionPolicy())
-		}
 	}
 }

--- a/packages/@prototype/api-geotracking/src/ApiGeotracking/QueryDrivers/index.ts
+++ b/packages/@prototype/api-geotracking/src/ApiGeotracking/QueryDrivers/index.ts
@@ -19,7 +19,7 @@ import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_iam as iam } from '
 import { MemoryDBCluster } from '@prototype/live-data-cache'
 import { namespaced } from '@aws-play/cdk-core'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
-import { LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
+import { LambdaInsightsExecutionPolicyStatements } from '@prototype/lambda-common'
 
 interface Environment extends DeclaredLambdaEnvironment {
 	readonly MEMORYDB_ADMIN_USERNAME: string
@@ -69,6 +69,7 @@ export class QueryDriversLambda extends DeclaredLambdaFunction<Environment, Depe
 						`${memoryDBCluster.adminPasswordSecret.secretArn}*`,
 					],
 				}),
+				...LambdaInsightsExecutionPolicyStatements(),
 			],
 			vpc,
 			vpcSubnets: {
@@ -78,9 +79,5 @@ export class QueryDriversLambda extends DeclaredLambdaFunction<Environment, Depe
 		}
 
 		super(scope, id, declaredProps)
-
-		if (this.role) {
-			this.role.addManagedPolicy(LambdaInsightsExecutionPolicy())
-		}
 	}
 }

--- a/packages/@prototype/instant-delivery-provider/src/DispatchEngineOrchestrator/OrchestratorHelperLambda/index.ts
+++ b/packages/@prototype/instant-delivery-provider/src/DispatchEngineOrchestrator/OrchestratorHelperLambda/index.ts
@@ -19,7 +19,7 @@ import { Duration, aws_lambda as lambda, aws_dynamodb as ddb, aws_events as even
 import { RestApi } from '@aws-play/cdk-apigateway'
 import { namespaced } from '@aws-play/cdk-core'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
-import { LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
+import { LambdaInsightsExecutionPolicyStatements } from '@prototype/lambda-common'
 import { SERVICE_NAME } from '@prototype/common'
 
 interface Environment extends DeclaredLambdaEnvironment {
@@ -139,13 +139,10 @@ export class OrchestratorHelperLambda extends DeclaredLambdaFunction<Environment
 						`${instantDeliveryProviderApiSecret.secretArn}*`,
 					],
 				}),
+				...LambdaInsightsExecutionPolicyStatements(),
 			],
 		}
 
 		super(scope, id, declaredProps)
-
-		if (this.role) {
-			this.role.addManagedPolicy(LambdaInsightsExecutionPolicy())
-		}
 	}
 }

--- a/packages/@prototype/instant-delivery-provider/src/DispatchEngineOrchestrator/OrderIngestLambda/index.ts
+++ b/packages/@prototype/instant-delivery-provider/src/DispatchEngineOrchestrator/OrderIngestLambda/index.ts
@@ -19,7 +19,7 @@ import { Duration, aws_kinesis as kinesis, aws_lambda as lambda, aws_iam as iam,
 import { namespaced } from '@aws-play/cdk-core'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
 import { Kinesis } from 'cdk-iam-actions/lib/actions'
-import { LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
+import { LambdaInsightsExecutionPolicyStatements } from '@prototype/lambda-common'
 
 interface Environment extends DeclaredLambdaEnvironment {
 	readonly GEO_CLUSTERING_MANAGER_ARN: string
@@ -69,13 +69,10 @@ export class OrderIngestLambda extends DeclaredLambdaFunction<Environment, Depen
 					],
 					effect: iam.Effect.ALLOW,
 				}),
+				...LambdaInsightsExecutionPolicyStatements(),
 			],
 		}
 
 		super(scope, id, declaredProps)
-
-		if (this.role) {
-			this.role.addManagedPolicy(LambdaInsightsExecutionPolicy())
-		}
 	}
 }

--- a/packages/@prototype/instant-delivery-provider/src/DriverEventHandler/DriverCleanupFunction/index.ts
+++ b/packages/@prototype/instant-delivery-provider/src/DriverEventHandler/DriverCleanupFunction/index.ts
@@ -18,7 +18,7 @@ import { Construct } from 'constructs'
 import { Duration, aws_dynamodb as ddb, aws_kinesis as kinesis, aws_lambda as lambda, aws_iam as iam } from 'aws-cdk-lib'
 import { namespaced } from '@aws-play/cdk-core'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
-import { LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
+import { LambdaInsightsExecutionPolicyStatements } from '@prototype/lambda-common'
 
 interface Environment extends DeclaredLambdaEnvironment {
 	readonly PROVIDER_LOCKS_TABLE: string
@@ -81,13 +81,10 @@ export class DriverCleanupLambda extends DeclaredLambdaFunction<Environment, Dep
 						`${instantDeliveryProviderOrders.tableArn}/index/${instantDeliveryProviderOrdersStatusIndex}`,
 					],
 				}),
+				...LambdaInsightsExecutionPolicyStatements(),
 			],
 		}
 
 		super(scope, id, declaredProps)
-
-		if (this.role) {
-			this.role.addManagedPolicy(LambdaInsightsExecutionPolicy())
-		}
 	}
 }

--- a/packages/@prototype/instant-delivery-provider/src/DriverEventHandler/DriverStatusChangeHandler/index.ts
+++ b/packages/@prototype/instant-delivery-provider/src/DriverEventHandler/DriverStatusChangeHandler/index.ts
@@ -19,7 +19,7 @@ import { Duration, aws_dynamodb as ddb, aws_events as events, aws_secretsmanager
 import { namespaced } from '@aws-play/cdk-core'
 import { RestApi } from '@aws-play/cdk-apigateway'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
-import { LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
+import { LambdaInsightsExecutionPolicyStatements } from '@prototype/lambda-common'
 import { SERVICE_NAME } from '@prototype/common'
 
 interface Environment extends DeclaredLambdaEnvironment {
@@ -96,13 +96,10 @@ export class DriverStatusChangeHandler extends DeclaredLambdaFunction<Environmen
 						`${instantDeliveryProviderApiSecret.secretArn}*`,
 					],
 				}),
+				...LambdaInsightsExecutionPolicyStatements(),
 			],
 		}
 
 		super(scope, id, declaredProps)
-
-		if (this.role) {
-			this.role.addManagedPolicy(LambdaInsightsExecutionPolicy())
-		}
 	}
 }

--- a/packages/@prototype/lambda-common/src/LambdaInsights/index.ts
+++ b/packages/@prototype/lambda-common/src/LambdaInsights/index.ts
@@ -17,8 +17,22 @@
 import { Construct } from 'constructs'
 import { Stack, aws_lambda as lambda, aws_iam as iam } from 'aws-cdk-lib'
 
-export const LambdaInsightsExecutionPolicy = (): iam.IManagedPolicy => {
-	return iam.ManagedPolicy.fromAwsManagedPolicyName('CloudWatchLambdaInsightsExecutionRolePolicy')
+export const LambdaInsightsExecutionPolicyStatements = (): iam.PolicyStatement[] => {
+	return [
+		new iam.PolicyStatement({
+			actions: ['logs:CreateLogGroup'],
+			effect: iam.Effect.ALLOW,
+			resources: ['*'],
+		}),
+		new iam.PolicyStatement({
+			actions: [
+				'logs:CreateLogStream',
+				'logs:PutLogEvents',
+			],
+			effect: iam.Effect.ALLOW,
+			resources: ['arn:aws:logs:*:*:log-group:/aws/lambda-insights:*'],
+		}),
+	]
 }
 
 export const LambdaInsightsLayer = (scope: Construct, id: string): lambda.LayerVersion => {

--- a/packages/@prototype/lambda-functions/src/LambdaFunctions/DriverGeofencingLambda/index.ts
+++ b/packages/@prototype/lambda-functions/src/LambdaFunctions/DriverGeofencingLambda/index.ts
@@ -20,7 +20,7 @@ import { namespaced } from '@aws-play/cdk-core'
 import { MemoryDBCluster } from '@prototype/live-data-cache'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
 import { Kinesis } from 'cdk-iam-actions/lib/actions'
-import { LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
+import { LambdaInsightsExecutionPolicyStatements } from '@prototype/lambda-common'
 import { SERVICE_NAME } from '@prototype/common'
 
 export interface DriverGeofencingtLambdaExternalDeps {
@@ -103,6 +103,7 @@ export class DriverGeofencingtLambda extends DeclaredLambdaFunction<Environment,
 						`${memoryDBCluster.adminPasswordSecret.secretArn}*`,
 					],
 				}),
+				...LambdaInsightsExecutionPolicyStatements(),
 			],
 			layers: lambdaLayers,
 			vpc,
@@ -113,9 +114,5 @@ export class DriverGeofencingtLambda extends DeclaredLambdaFunction<Environment,
 		}
 
 		super(scope, id, declaredProps)
-
-		if (this.role) {
-			this.role.addManagedPolicy(LambdaInsightsExecutionPolicy())
-		}
 	}
 }

--- a/packages/@prototype/lambda-functions/src/LambdaFunctions/DriverLocationCleanupLambda/index.ts
+++ b/packages/@prototype/lambda-functions/src/LambdaFunctions/DriverLocationCleanupLambda/index.ts
@@ -19,7 +19,7 @@ import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_opensearchservice a
 import { namespaced } from '@aws-play/cdk-core'
 import { MemoryDBCluster } from '@prototype/live-data-cache'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
-import { AllowOpenSearchDelete, AllowOpenSearchWrite, LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
+import { AllowOpenSearchDelete, AllowOpenSearchWrite, LambdaInsightsExecutionPolicyStatements } from '@prototype/lambda-common'
 
 interface Environment extends DeclaredLambdaEnvironment {
 	readonly MEMORYDB_ADMIN_USERNAME: string
@@ -79,6 +79,7 @@ export class DriverLocationCleanupLambda extends DeclaredLambdaFunction<Environm
 						`${memoryDBCluster.adminPasswordSecret.secretArn}*`,
 					],
 				}),
+				...LambdaInsightsExecutionPolicyStatements(),
 			],
 			vpc,
 			vpcSubnets: {
@@ -88,9 +89,5 @@ export class DriverLocationCleanupLambda extends DeclaredLambdaFunction<Environm
 		}
 
 		super(scope, id, declaredProps)
-
-		if (this.role) {
-			this.role.addManagedPolicy(LambdaInsightsExecutionPolicy())
-		}
 	}
 }

--- a/packages/@prototype/lambda-functions/src/LambdaFunctions/DriverLocationUpdateIngestLambda/index.ts
+++ b/packages/@prototype/lambda-functions/src/LambdaFunctions/DriverLocationUpdateIngestLambda/index.ts
@@ -20,7 +20,7 @@ import { MemoryDBCluster } from '@prototype/live-data-cache'
 import { namespaced } from '@aws-play/cdk-core'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
 import { Kinesis } from 'cdk-iam-actions/lib/actions'
-import { AllowOpenSearchWrite, LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
+import { AllowOpenSearchWrite, LambdaInsightsExecutionPolicyStatements } from '@prototype/lambda-common'
 
 export interface DriverLocationUpdateIngestLambdaExternalDeps {
 	readonly vpc: ec2.IVpc
@@ -99,6 +99,7 @@ export class DriverLocationUpdateIngestLambda extends DeclaredLambdaFunction<Env
 						`${memoryDBCluster.adminPasswordSecret.secretArn}*`,
 					],
 				}),
+				...LambdaInsightsExecutionPolicyStatements(),
 			],
 			layers: lambdaLayers,
 			vpc,
@@ -109,9 +110,5 @@ export class DriverLocationUpdateIngestLambda extends DeclaredLambdaFunction<Env
 		}
 
 		super(scope, id, declaredProps)
-
-		if (this.role) {
-			this.role.addManagedPolicy(LambdaInsightsExecutionPolicy())
-		}
 	}
 }

--- a/packages/@prototype/lambda-functions/src/LambdaFunctions/DriverStatusUpdateIngestLambda/index.ts
+++ b/packages/@prototype/lambda-functions/src/LambdaFunctions/DriverStatusUpdateIngestLambda/index.ts
@@ -19,7 +19,7 @@ import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_events as events, a
 import { namespaced } from '@aws-play/cdk-core'
 import { MemoryDBCluster } from '@prototype/live-data-cache'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
-import { AllowOpenSearchWrite, LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
+import { AllowOpenSearchWrite, LambdaInsightsExecutionPolicyStatements } from '@prototype/lambda-common'
 import { SERVICE_NAME } from '@prototype/common'
 
 interface Environment extends DeclaredLambdaEnvironment {
@@ -87,6 +87,7 @@ export class DriverStatusUpdateLambda extends DeclaredLambdaFunction<Environment
 					],
 				}),
 				AllowOpenSearchWrite(openSearchDomain.domainArn),
+				...LambdaInsightsExecutionPolicyStatements(),
 			],
 			layers: lambdaLayers,
 			vpc,
@@ -97,9 +98,5 @@ export class DriverStatusUpdateLambda extends DeclaredLambdaFunction<Environment
 		}
 
 		super(scope, id, declaredProps)
-
-		if (this.role) {
-			this.role.addManagedPolicy(LambdaInsightsExecutionPolicy())
-		}
 	}
 }

--- a/packages/@prototype/order-manager/src/OrderManager/OrderManagerHandler/index.ts
+++ b/packages/@prototype/order-manager/src/OrderManager/OrderManagerHandler/index.ts
@@ -20,7 +20,7 @@ import { MemoryDBCluster } from '@prototype/live-data-cache'
 import { Networking } from '@prototype/networking'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
 import { namespaced } from '@aws-play/cdk-core'
-import { LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
+import { LambdaInsightsExecutionPolicyStatements } from '@prototype/lambda-common'
 import { SERVICE_NAME } from '@prototype/common'
 
 interface Environment extends DeclaredLambdaEnvironment {
@@ -108,6 +108,7 @@ export class OrderManagerHandlerLambda extends DeclaredLambdaFunction<Environmen
 						`${memoryDBCluster.adminPasswordSecret.secretArn}*`,
 					],
 				}),
+				...LambdaInsightsExecutionPolicyStatements(),
 			],
 			vpc: privateVpc,
 			layers: [
@@ -122,9 +123,5 @@ export class OrderManagerHandlerLambda extends DeclaredLambdaFunction<Environmen
 		}
 
 		super(scope, id, declaredProps)
-
-		if (this.role) {
-			this.role.addManagedPolicy(LambdaInsightsExecutionPolicy())
-		}
 	}
 }

--- a/packages/@prototype/order-manager/src/OrderManager/OrderManagerHelper/index.ts
+++ b/packages/@prototype/order-manager/src/OrderManager/OrderManagerHelper/index.ts
@@ -20,7 +20,7 @@ import { Networking } from '@prototype/networking'
 import { MemoryDBCluster } from '@prototype/live-data-cache'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
 import { namespaced } from '@aws-play/cdk-core'
-import { LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
+import { LambdaInsightsExecutionPolicyStatements } from '@prototype/lambda-common'
 import { SERVICE_NAME } from '@prototype/common'
 
 interface Environment extends DeclaredLambdaEnvironment {
@@ -95,6 +95,7 @@ export class OrderManagerHelperLambda extends DeclaredLambdaFunction<Environment
 						`${memoryDBCluster.adminPasswordSecret.secretArn}*`,
 					],
 				}),
+				...LambdaInsightsExecutionPolicyStatements(),
 			],
 			vpc: privateVpc,
 			layers: [
@@ -109,9 +110,5 @@ export class OrderManagerHelperLambda extends DeclaredLambdaFunction<Environment
 		}
 
 		super(scope, id, declaredProps)
-
-		if (this.role) {
-			this.role.addManagedPolicy(LambdaInsightsExecutionPolicy())
-		}
 	}
 }

--- a/packages/@prototype/order-manager/src/OrderManager/ProviderRuleEngine/index.ts
+++ b/packages/@prototype/order-manager/src/OrderManager/ProviderRuleEngine/index.ts
@@ -18,7 +18,7 @@ import { Construct } from 'constructs'
 import { Duration, aws_lambda as lambda, aws_dynamodb as ddb, aws_iam as iam, aws_apigateway as apigw, aws_secretsmanager as secretsmanager } from 'aws-cdk-lib'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
 import { namespaced } from '@aws-play/cdk-core'
-import { LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
+import { LambdaInsightsExecutionPolicyStatements } from '@prototype/lambda-common'
 
 interface Environment extends DeclaredLambdaEnvironment {
 	PROVIDERS: string
@@ -82,13 +82,10 @@ export class ProviderRuleEngineLambda extends DeclaredLambdaFunction<Environment
 						`${instantDeliveryProviderSecret.secretArn}*`,
 					],
 				}),
+				...LambdaInsightsExecutionPolicyStatements(),
 			],
 		}
 
 		super(scope, id, declaredProps)
-
-		if (this.role) {
-			this.role.addManagedPolicy(LambdaInsightsExecutionPolicy())
-		}
 	}
 }

--- a/packages/@prototype/provider-impl/src/ExamplePollingProvider/lambdas/CancelOrder/index.ts
+++ b/packages/@prototype/provider-impl/src/ExamplePollingProvider/lambdas/CancelOrder/index.ts
@@ -19,7 +19,7 @@ import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_secretsmanager as s
 import { namespaced } from '@aws-play/cdk-core'
 import { MemoryDBCluster } from '@prototype/live-data-cache'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
-import { LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
+import { LambdaInsightsExecutionPolicyStatements } from '@prototype/lambda-common'
 import { SERVICE_NAME, PROVIDER_NAME } from '@prototype/common'
 
 interface Environment extends DeclaredLambdaEnvironment {
@@ -95,6 +95,7 @@ export class CancelOrderLambda extends DeclaredLambdaFunction<Environment, Depen
 						`${memoryDBCluster.adminPasswordSecret.secretArn}*`,
 					],
 				}),
+				...LambdaInsightsExecutionPolicyStatements(),
 			],
 			layers: lambdaLayers,
 			vpc,
@@ -105,9 +106,5 @@ export class CancelOrderLambda extends DeclaredLambdaFunction<Environment, Depen
 		}
 
 		super(scope, id, declaredProps)
-
-		if (this.role) {
-			this.role.addManagedPolicy(LambdaInsightsExecutionPolicy())
-		}
 	}
 }

--- a/packages/@prototype/provider-impl/src/ExamplePollingProvider/lambdas/ExamplePolling/index.ts
+++ b/packages/@prototype/provider-impl/src/ExamplePollingProvider/lambdas/ExamplePolling/index.ts
@@ -19,7 +19,7 @@ import { Duration, aws_ec2 as ec2, aws_secretsmanager as secretsmanager, aws_lam
 import { MemoryDBCluster } from '@prototype/live-data-cache'
 import { namespaced } from '@aws-play/cdk-core'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
-import { LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
+import { LambdaInsightsExecutionPolicyStatements } from '@prototype/lambda-common'
 import { SERVICE_NAME, PROVIDER_NAME } from '@prototype/common'
 
 interface Environment extends DeclaredLambdaEnvironment {
@@ -108,6 +108,7 @@ export class ExamplePollingLambda extends DeclaredLambdaFunction<Environment, De
 						`${memoryDBCluster.adminPasswordSecret.secretArn}*`,
 					],
 				}),
+				...LambdaInsightsExecutionPolicyStatements(),
 			],
 			layers: lambdaLayers,
 			vpc,
@@ -118,9 +119,5 @@ export class ExamplePollingLambda extends DeclaredLambdaFunction<Environment, De
 		}
 
 		super(scope, id, declaredProps)
-
-		if (this.role) {
-			this.role.addManagedPolicy(LambdaInsightsExecutionPolicy())
-		}
 	}
 }

--- a/packages/@prototype/provider-impl/src/ExamplePollingProvider/lambdas/GetOrderStatus/index.ts
+++ b/packages/@prototype/provider-impl/src/ExamplePollingProvider/lambdas/GetOrderStatus/index.ts
@@ -19,7 +19,7 @@ import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_secretsmanager as s
 import { namespaced } from '@aws-play/cdk-core'
 import { MemoryDBCluster } from '@prototype/live-data-cache'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
-import { LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
+import { LambdaInsightsExecutionPolicyStatements } from '@prototype/lambda-common'
 import { SERVICE_NAME, PROVIDER_NAME } from '@prototype/common'
 
 interface Environment extends DeclaredLambdaEnvironment {
@@ -95,6 +95,7 @@ export class GetOrderStatusLambda extends DeclaredLambdaFunction<Environment, De
 						`${memoryDBCluster.adminPasswordSecret.secretArn}*`,
 					],
 				}),
+				...LambdaInsightsExecutionPolicyStatements(),
 			],
 			layers: lambdaLayers,
 			vpc,
@@ -105,9 +106,5 @@ export class GetOrderStatusLambda extends DeclaredLambdaFunction<Environment, De
 		}
 
 		super(scope, id, declaredProps)
-
-		if (this.role) {
-			this.role.addManagedPolicy(LambdaInsightsExecutionPolicy())
-		}
 	}
 }

--- a/packages/@prototype/provider-impl/src/ExamplePollingProvider/lambdas/RequestOrderFulfillment/index.ts
+++ b/packages/@prototype/provider-impl/src/ExamplePollingProvider/lambdas/RequestOrderFulfillment/index.ts
@@ -19,7 +19,7 @@ import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_events as events, a
 import { namespaced } from '@aws-play/cdk-core'
 import { MemoryDBCluster } from '@prototype/live-data-cache'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
-import { LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
+import { LambdaInsightsExecutionPolicyStatements } from '@prototype/lambda-common'
 import { SERVICE_NAME, PROVIDER_NAME } from '@prototype/common'
 
 interface Environment extends DeclaredLambdaEnvironment {
@@ -116,6 +116,7 @@ export class RequestOrderFulfillmentLambda extends DeclaredLambdaFunction<Enviro
 						pendingOrdersQueue.queueArn,
 					],
 				}),
+				...LambdaInsightsExecutionPolicyStatements(),
 			],
 			layers: lambdaLayers,
 			vpc,
@@ -126,9 +127,5 @@ export class RequestOrderFulfillmentLambda extends DeclaredLambdaFunction<Enviro
 		}
 
 		super(scope, id, declaredProps)
-
-		if (this.role) {
-			this.role.addManagedPolicy(LambdaInsightsExecutionPolicy())
-		}
 	}
 }

--- a/packages/@prototype/provider-impl/src/ExampleWebhookProvider/lambdas/CancelOrder/index.ts
+++ b/packages/@prototype/provider-impl/src/ExampleWebhookProvider/lambdas/CancelOrder/index.ts
@@ -19,7 +19,7 @@ import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_secretsmanager as s
 import { namespaced } from '@aws-play/cdk-core'
 import { MemoryDBCluster } from '@prototype/live-data-cache'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
-import { LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
+import { LambdaInsightsExecutionPolicyStatements } from '@prototype/lambda-common'
 import { SERVICE_NAME, PROVIDER_NAME } from '@prototype/common'
 
 interface Environment extends DeclaredLambdaEnvironment {
@@ -92,6 +92,7 @@ export class CancelOrderLambda extends DeclaredLambdaFunction<Environment, Depen
 						`${memoryDBCluster.adminPasswordSecret.secretArn}*`,
 					],
 				}),
+				...LambdaInsightsExecutionPolicyStatements(),
 			],
 			layers: lambdaLayers,
 			vpc,
@@ -102,9 +103,5 @@ export class CancelOrderLambda extends DeclaredLambdaFunction<Environment, Depen
 		}
 
 		super(scope, id, declaredProps)
-
-		if (this.role) {
-			this.role.addManagedPolicy(LambdaInsightsExecutionPolicy())
-		}
 	}
 }

--- a/packages/@prototype/provider-impl/src/ExampleWebhookProvider/lambdas/ExampleCallback/index.ts
+++ b/packages/@prototype/provider-impl/src/ExampleWebhookProvider/lambdas/ExampleCallback/index.ts
@@ -19,7 +19,7 @@ import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_events as events, a
 import { MemoryDBCluster } from '@prototype/live-data-cache'
 import { namespaced } from '@aws-play/cdk-core'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
-import { LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
+import { LambdaInsightsExecutionPolicyStatements } from '@prototype/lambda-common'
 import { SERVICE_NAME, PROVIDER_NAME } from '@prototype/common'
 
 interface Environment extends DeclaredLambdaEnvironment {
@@ -83,6 +83,7 @@ export class ExampleCallbackLambda extends DeclaredLambdaFunction<Environment, D
 						`${memoryDBCluster.adminPasswordSecret.secretArn}*`,
 					],
 				}),
+				...LambdaInsightsExecutionPolicyStatements(),
 			],
 			layers: lambdaLayers,
 			vpc,
@@ -93,9 +94,5 @@ export class ExampleCallbackLambda extends DeclaredLambdaFunction<Environment, D
 		}
 
 		super(scope, id, declaredProps)
-
-		if (this.role) {
-			this.role.addManagedPolicy(LambdaInsightsExecutionPolicy())
-		}
 	}
 }

--- a/packages/@prototype/provider-impl/src/ExampleWebhookProvider/lambdas/GetOrderStatus/index.ts
+++ b/packages/@prototype/provider-impl/src/ExampleWebhookProvider/lambdas/GetOrderStatus/index.ts
@@ -19,7 +19,7 @@ import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_secretsmanager as s
 import { MemoryDBCluster } from '@prototype/live-data-cache'
 import { namespaced } from '@aws-play/cdk-core'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
-import { LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
+import { LambdaInsightsExecutionPolicyStatements } from '@prototype/lambda-common'
 import { SERVICE_NAME, PROVIDER_NAME } from '@prototype/common'
 
 interface Environment extends DeclaredLambdaEnvironment {
@@ -92,6 +92,7 @@ export class GetOrderStatusLambda extends DeclaredLambdaFunction<Environment, De
 						`${memoryDBCluster.adminPasswordSecret.secretArn}*`,
 					],
 				}),
+				...LambdaInsightsExecutionPolicyStatements(),
 			],
 			layers: lambdaLayers,
 			vpc,
@@ -102,9 +103,5 @@ export class GetOrderStatusLambda extends DeclaredLambdaFunction<Environment, De
 		}
 
 		super(scope, id, declaredProps)
-
-		if (this.role) {
-			this.role.addManagedPolicy(LambdaInsightsExecutionPolicy())
-		}
 	}
 }

--- a/packages/@prototype/provider-impl/src/ExampleWebhookProvider/lambdas/RequestOrderFulfillment/index.ts
+++ b/packages/@prototype/provider-impl/src/ExampleWebhookProvider/lambdas/RequestOrderFulfillment/index.ts
@@ -19,7 +19,7 @@ import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_events as events, a
 import { MemoryDBCluster } from '@prototype/live-data-cache'
 import { namespaced } from '@aws-play/cdk-core'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
-import { LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
+import { LambdaInsightsExecutionPolicyStatements } from '@prototype/lambda-common'
 import { SERVICE_NAME, PROVIDER_NAME } from '@prototype/common'
 
 interface Environment extends DeclaredLambdaEnvironment {
@@ -100,6 +100,7 @@ export class RequestOrderFulfillmentLambda extends DeclaredLambdaFunction<Enviro
 						`${memoryDBCluster.adminPasswordSecret.secretArn}*`,
 					],
 				}),
+				...LambdaInsightsExecutionPolicyStatements(),
 			],
 			layers: lambdaLayers,
 			vpc,
@@ -110,10 +111,6 @@ export class RequestOrderFulfillmentLambda extends DeclaredLambdaFunction<Enviro
 		}
 
 		super(scope, id, declaredProps)
-
-		if (this.role) {
-			this.role.addManagedPolicy(LambdaInsightsExecutionPolicy())
-		}
 
 		this.environmentVariables = environmentVariables
 	}

--- a/packages/@prototype/provider-impl/src/InstantDeliveryProvider/lambdas/CancelOrder/index.ts
+++ b/packages/@prototype/provider-impl/src/InstantDeliveryProvider/lambdas/CancelOrder/index.ts
@@ -18,7 +18,7 @@ import { Construct } from 'constructs'
 import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_events as events, aws_iam as iam, aws_dynamodb as ddb } from 'aws-cdk-lib'
 import { namespaced } from '@aws-play/cdk-core'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
-import { LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
+import { LambdaInsightsExecutionPolicyStatements } from '@prototype/lambda-common'
 import { SERVICE_NAME, PROVIDER_NAME } from '@prototype/common'
 
 interface Environment extends DeclaredLambdaEnvironment {
@@ -73,6 +73,7 @@ export class CancelOrderLambda extends DeclaredLambdaFunction<Environment, Depen
 					effect: iam.Effect.ALLOW,
 					resources: [instantDeliveryProviderOrders.tableArn],
 				}),
+				...LambdaInsightsExecutionPolicyStatements(),
 			],
 			layers: lambdaLayers,
 			vpc,
@@ -83,9 +84,5 @@ export class CancelOrderLambda extends DeclaredLambdaFunction<Environment, Depen
 		}
 
 		super(scope, id, declaredProps)
-
-		if (this.role) {
-			this.role.addManagedPolicy(LambdaInsightsExecutionPolicy())
-		}
 	}
 }

--- a/packages/@prototype/provider-impl/src/InstantDeliveryProvider/lambdas/GetOrderStatus/index.ts
+++ b/packages/@prototype/provider-impl/src/InstantDeliveryProvider/lambdas/GetOrderStatus/index.ts
@@ -18,7 +18,7 @@ import { Construct } from 'constructs'
 import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_events as events, aws_iam as iam, aws_dynamodb as ddb } from 'aws-cdk-lib'
 import { namespaced } from '@aws-play/cdk-core'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
-import { LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
+import { LambdaInsightsExecutionPolicyStatements } from '@prototype/lambda-common'
 import { SERVICE_NAME, PROVIDER_NAME } from '@prototype/common'
 
 interface Environment extends DeclaredLambdaEnvironment {
@@ -73,6 +73,7 @@ export class GetOrderStatusLambda extends DeclaredLambdaFunction<Environment, De
 					effect: iam.Effect.ALLOW,
 					resources: [instantDeliveryProviderOrders.tableArn],
 				}),
+				...LambdaInsightsExecutionPolicyStatements(),
 			],
 			layers: lambdaLayers,
 			vpc,
@@ -83,9 +84,5 @@ export class GetOrderStatusLambda extends DeclaredLambdaFunction<Environment, De
 		}
 
 		super(scope, id, declaredProps)
-
-		if (this.role) {
-			this.role.addManagedPolicy(LambdaInsightsExecutionPolicy())
-		}
 	}
 }

--- a/packages/@prototype/provider-impl/src/InstantDeliveryProvider/lambdas/InstantDeliveryProviderCallback/index.ts
+++ b/packages/@prototype/provider-impl/src/InstantDeliveryProvider/lambdas/InstantDeliveryProviderCallback/index.ts
@@ -18,7 +18,7 @@ import { Construct } from 'constructs'
 import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_events as events, aws_iam as iam } from 'aws-cdk-lib'
 import { namespaced } from '@aws-play/cdk-core'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
-import { LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
+import { LambdaInsightsExecutionPolicyStatements } from '@prototype/lambda-common'
 import { SERVICE_NAME } from '@prototype/common'
 
 interface Environment extends DeclaredLambdaEnvironment {
@@ -62,6 +62,7 @@ export class InstantDeliveryProviderCallbackLambda extends DeclaredLambdaFunctio
 					effect: iam.Effect.ALLOW,
 					resources: [eventBus.eventBusArn],
 				}),
+				...LambdaInsightsExecutionPolicyStatements(),
 			],
 			layers: lambdaLayers,
 			vpc,
@@ -72,9 +73,5 @@ export class InstantDeliveryProviderCallbackLambda extends DeclaredLambdaFunctio
 		}
 
 		super(scope, id, declaredProps)
-
-		if (this.role) {
-			this.role.addManagedPolicy(LambdaInsightsExecutionPolicy())
-		}
 	}
 }

--- a/packages/@prototype/provider-impl/src/InstantDeliveryProvider/lambdas/RequestOrderFulfillment/index.ts
+++ b/packages/@prototype/provider-impl/src/InstantDeliveryProvider/lambdas/RequestOrderFulfillment/index.ts
@@ -18,7 +18,7 @@ import { Construct } from 'constructs'
 import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_events as events, aws_iam as iam, aws_kinesis as kinesis, aws_dynamodb as ddb } from 'aws-cdk-lib'
 import { namespaced } from '@aws-play/cdk-core'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
-import { LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
+import { LambdaInsightsExecutionPolicyStatements } from '@prototype/lambda-common'
 import { SERVICE_NAME, PROVIDER_NAME } from '@prototype/common'
 
 interface Environment extends DeclaredLambdaEnvironment {
@@ -81,6 +81,7 @@ export class RequestOrderFulfillmentLambda extends DeclaredLambdaFunction<Enviro
 					effect: iam.Effect.ALLOW,
 					resources: [instantDeliveryProviderOrders.tableArn],
 				}),
+				...LambdaInsightsExecutionPolicyStatements(),
 			],
 			layers: lambdaLayers,
 			vpc,
@@ -91,9 +92,5 @@ export class RequestOrderFulfillmentLambda extends DeclaredLambdaFunction<Enviro
 		}
 
 		super(scope, id, declaredProps)
-
-		if (this.role) {
-			this.role.addManagedPolicy(LambdaInsightsExecutionPolicy())
-		}
 	}
 }

--- a/packages/@prototype/simulator/src/SimulatorManagerStack/DestinationSimulatorLambda/DestinationStatusUpdateLambda/index.ts
+++ b/packages/@prototype/simulator/src/SimulatorManagerStack/DestinationSimulatorLambda/DestinationStatusUpdateLambda/index.ts
@@ -19,7 +19,7 @@ import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_events as events, a
 import { namespaced } from '@aws-play/cdk-core'
 import { MemoryDBCluster } from '@prototype/live-data-cache'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
-import { LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
+import { LambdaInsightsExecutionPolicyStatements } from '@prototype/lambda-common'
 import { SERVICE_NAME } from '@prototype/common'
 
 interface Environment extends DeclaredLambdaEnvironment {
@@ -82,6 +82,7 @@ export class DestinationStatusUpdateLambda extends DeclaredLambdaFunction<Enviro
 						`${memoryDBCluster.adminPasswordSecret.secretArn}*`,
 					],
 				}),
+				...LambdaInsightsExecutionPolicyStatements(),
 			],
 			layers: lambdaLayers,
 			vpc,
@@ -92,9 +93,5 @@ export class DestinationStatusUpdateLambda extends DeclaredLambdaFunction<Enviro
 		}
 
 		super(scope, id, declaredProps)
-
-		if (this.role) {
-			this.role.addManagedPolicy(LambdaInsightsExecutionPolicy())
-		}
 	}
 }

--- a/packages/@prototype/simulator/src/SimulatorManagerStack/OriginSimulatorLambda/OriginEventHandler/index.ts
+++ b/packages/@prototype/simulator/src/SimulatorManagerStack/OriginSimulatorLambda/OriginEventHandler/index.ts
@@ -18,7 +18,7 @@ import { Construct } from 'constructs'
 import { Duration, aws_lambda as lambda, aws_events as events, aws_iam as iam, aws_dynamodb as ddb } from 'aws-cdk-lib'
 import { namespaced } from '@aws-play/cdk-core'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
-import { LambdaInsightsExecutionPolicy, readDDBTablePolicyStatement } from '@prototype/lambda-common'
+import { LambdaInsightsExecutionPolicyStatements, readDDBTablePolicyStatement } from '@prototype/lambda-common'
 import { SERVICE_NAME } from '@prototype/common'
 
 interface Environment extends DeclaredLambdaEnvironment {
@@ -65,13 +65,10 @@ export class OriginEventHandlerLambda extends DeclaredLambdaFunction<Environment
 					effect: iam.Effect.ALLOW,
 					resources: ['*'],
 				}),
+				...LambdaInsightsExecutionPolicyStatements(),
 			],
 		}
 
 		super(scope, id, declaredProps)
-
-		if (this.role) {
-			this.role.addManagedPolicy(LambdaInsightsExecutionPolicy())
-		}
 	}
 }

--- a/packages/@prototype/simulator/src/SimulatorManagerStack/OriginSimulatorLambda/OriginStatusUpdateLambda/index.ts
+++ b/packages/@prototype/simulator/src/SimulatorManagerStack/OriginSimulatorLambda/OriginStatusUpdateLambda/index.ts
@@ -19,7 +19,7 @@ import { Duration, aws_ec2 as ec2, aws_lambda as lambda, aws_events as events, a
 import { namespaced } from '@aws-play/cdk-core'
 import { MemoryDBCluster } from '@prototype/live-data-cache'
 import { DeclaredLambdaFunction, ExposedDeclaredLambdaProps, DeclaredLambdaProps, DeclaredLambdaEnvironment, DeclaredLambdaDependencies } from '@aws-play/cdk-lambda'
-import { LambdaInsightsExecutionPolicy } from '@prototype/lambda-common'
+import { LambdaInsightsExecutionPolicyStatements } from '@prototype/lambda-common'
 import { SERVICE_NAME } from '@prototype/common'
 
 interface Environment extends DeclaredLambdaEnvironment {
@@ -82,6 +82,7 @@ export class OriginStatusUpdateLambda extends DeclaredLambdaFunction<Environment
 						`${memoryDBCluster.adminPasswordSecret.secretArn}*`,
 					],
 				}),
+				...LambdaInsightsExecutionPolicyStatements(),
 			],
 			layers: lambdaLayers,
 			vpc,
@@ -92,9 +93,5 @@ export class OriginStatusUpdateLambda extends DeclaredLambdaFunction<Environment
 		}
 
 		super(scope, id, declaredProps)
-
-		if (this.role) {
-			this.role.addManagedPolicy(LambdaInsightsExecutionPolicy())
-		}
 	}
 }


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:*

- remove usage of managed policies and replace it with IAM policies

**Note**: `AmazonSSMManagedInstanceCore` and `AWSCodeCommitReadOnly` are still present as part of the development components (codepipline and debug instances)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
