### PR TITLE
fix(infra): remove dummy method (ANY) from the RestApi construct

### DIFF
--- a/packages/@aws-play/cdk-apigateway/src/RestApi/index.ts
+++ b/packages/@aws-play/cdk-apigateway/src/RestApi/index.ts
@@ -50,9 +50,6 @@ export class RestApi extends apigw.RestApi {
 	constructor (scope: Construct, id: string, props: RestApiProps) {
 		super(scope, id, RestApi.defaultProps(props))
 
-		// dummy
-		this.root.addMethod('ANY')
-
 		let { restApiName } = props
 
 		if (!restApiName) {


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:*

- remove un-required _dummy_ method from the `RestApi` common construct


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
