### PR TITLE
chore(graphhopper): use Graphhopper5 in delivery-dispatch and docker images

### DIFF
--- a/packages/@prototype/dispatch-setup/src/GraphhopperSetup/docker/Dockerfile
+++ b/packages/@prototype/dispatch-setup/src/GraphhopperSetup/docker/Dockerfile
@@ -4,7 +4,7 @@
 FROM --platform=linux/arm64 debian:buster-slim as downloader
 
 ARG MAPFILE_URL=set_MAPFILE_URL_env_var
-ARG GRAPHHOPPER_VERSION=4.0
+ARG GRAPHHOPPER_VERSION=5.0
 
 WORKDIR /download
 

--- a/prototype/dispatch/delivery-dispatch/apps/instant-sequential/src/main/docker/Dockerfile
+++ b/prototype/dispatch/delivery-dispatch/apps/instant-sequential/src/main/docker/Dockerfile
@@ -4,7 +4,7 @@
 FROM --platform=linux/arm64 debian:buster-slim as downloader
 
 ARG MAPFILE_URL=set_MAPFILE_URL_env_var
-ARG GRAPHHOPPER_VERSION=4.0
+ARG GRAPHHOPPER_VERSION=5.0
 
 WORKDIR /download
 

--- a/prototype/dispatch/delivery-dispatch/apps/sameday-directpudo/src/main/docker/Dockerfile
+++ b/prototype/dispatch/delivery-dispatch/apps/sameday-directpudo/src/main/docker/Dockerfile
@@ -4,7 +4,7 @@
 FROM --platform=linux/arm64 debian:buster-slim as downloader
 
 ARG MAPFILE_URL=set_MAPFILE_URL_env_var
-ARG GRAPHHOPPER_VERSION=4.0
+ARG GRAPHHOPPER_VERSION=5.0
 
 WORKDIR /download
 

--- a/prototype/dispatch/delivery-dispatch/pom.xml
+++ b/prototype/dispatch/delivery-dispatch/pom.xml
@@ -48,10 +48,10 @@
     </licenses>
 
     <properties>
-        <awssdk.version>2.17.153</awssdk.version>
+        <awssdk.version>2.17.172</awssdk.version>
         <awssdk2-dynamo-json-helper.version>0.13.0</awssdk2-dynamo-json-helper.version>
         <compiler-plugin.version>3.10.0</compiler-plugin.version>
-        <graphhopper-core.version>4.0</graphhopper-core.version>
+        <graphhopper-core.version>5.0</graphhopper-core.version>
         <graphhopper-reader-osm.version>3.0-pre3</graphhopper-reader-osm.version>
         <h3.version>3.7.2</h3.version>
         <jobrunr.version>4.0.9</jobrunr.version>

--- a/reports/docker/delivery-dispatch-instant-sequential-report.txt
+++ b/reports/docker/delivery-dispatch-instant-sequential-report.txt
@@ -1,21 +1,14 @@
-2022-04-20T17:43:44.017+0800	[34mINFO[0m	Detected OS: amazon
-2022-04-20T17:43:44.018+0800	[34mINFO[0m	Detecting Amazon Linux vulnerabilities...
-2022-04-20T17:43:44.025+0800	[34mINFO[0m	Number of language-specific files: 1
-2022-04-20T17:43:44.025+0800	[34mINFO[0m	Detecting jar vulnerabilities...
+2022-04-20T19:17:08.319+0800	[34mINFO[0m	Detected OS: amazon
+2022-04-20T19:17:08.320+0800	[34mINFO[0m	Detecting Amazon Linux vulnerabilities...
+2022-04-20T19:17:08.331+0800	[34mINFO[0m	Number of language-specific files: 1
+2022-04-20T19:17:08.331+0800	[34mINFO[0m	Detecting jar vulnerabilities...
 
 delivery-dispatch-instant-seq-docker:latest (amazon 2 (Karoo))
 ==============================================================
 Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
 
-2022-04-20T17:43:44.081+0800	[34mINFO[0m	Table result includes only package filenames. Use '--format json' option to get the full path to the package file.
 
 Java (jar)
 ==========
-Total: 1 (UNKNOWN: 0, LOW: 0, MEDIUM: 1, HIGH: 0, CRITICAL: 0)
+Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
 
-+---------------------------------------------------+------------------+----------+-------------------+---------------+---------------------------------------+
-|                      LIBRARY                      | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |                 TITLE                 |
-+---------------------------------------------------+------------------+----------+-------------------+---------------+---------------------------------------+
-| com.graphhopper:graphhopper-core                  | CVE-2021-23408   | MEDIUM   |               4.0 |           3.2 | Prototype Pollution in GraphHopper    |
-| (delivery-dispatch-instant-sequential-runner.jar) |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-23408 |
-+---------------------------------------------------+------------------+----------+-------------------+---------------+---------------------------------------+

--- a/reports/docker/delivery-dispatch-sameday-directpudo-report.txt
+++ b/reports/docker/delivery-dispatch-sameday-directpudo-report.txt
@@ -1,21 +1,14 @@
-2022-04-20T17:42:57.637+0800	[34mINFO[0m	Detected OS: amazon
-2022-04-20T17:42:57.637+0800	[34mINFO[0m	Detecting Amazon Linux vulnerabilities...
-2022-04-20T17:42:57.645+0800	[34mINFO[0m	Number of language-specific files: 1
-2022-04-20T17:42:57.645+0800	[34mINFO[0m	Detecting jar vulnerabilities...
+2022-04-20T19:19:43.799+0800	[34mINFO[0m	Detected OS: amazon
+2022-04-20T19:19:43.799+0800	[34mINFO[0m	Detecting Amazon Linux vulnerabilities...
+2022-04-20T19:19:43.808+0800	[34mINFO[0m	Number of language-specific files: 1
+2022-04-20T19:19:43.808+0800	[34mINFO[0m	Detecting jar vulnerabilities...
 
 delivery-dispatch-sameday-directpudo-docker:latest (amazon 2 (Karoo))
 =====================================================================
 Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
 
-2022-04-20T17:42:57.650+0800	[34mINFO[0m	Table result includes only package filenames. Use '--format json' option to get the full path to the package file.
 
 Java (jar)
 ==========
-Total: 1 (UNKNOWN: 0, LOW: 0, MEDIUM: 1, HIGH: 0, CRITICAL: 0)
+Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
 
-+---------------------------------------------------+------------------+----------+-------------------+---------------+---------------------------------------+
-|                      LIBRARY                      | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |                 TITLE                 |
-+---------------------------------------------------+------------------+----------+-------------------+---------------+---------------------------------------+
-| com.graphhopper:graphhopper-core                  | CVE-2021-23408   | MEDIUM   |               4.0 |           3.2 | Prototype Pollution in GraphHopper    |
-| (delivery-dispatch-sameday-directpudo-runner.jar) |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-23408 |
-+---------------------------------------------------+------------------+----------+-------------------+---------------+---------------------------------------+

--- a/reports/docker/graphhopper-50-report.txt
+++ b/reports/docker/graphhopper-50-report.txt
@@ -1,0 +1,53 @@
+2022-04-20T19:21:28.058+0800	[34mINFO[0m	Detected OS: amazon
+2022-04-20T19:21:28.059+0800	[34mINFO[0m	Detecting Amazon Linux vulnerabilities...
+2022-04-20T19:21:28.067+0800	[34mINFO[0m	Number of language-specific files: 1
+2022-04-20T19:21:28.067+0800	[34mINFO[0m	Detecting jar vulnerabilities...
+
+graphhopper:latest (amazon 2 (Karoo))
+=====================================
+Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
+
+2022-04-20T19:21:28.072+0800	[34mINFO[0m	Table result includes only package filenames. Use '--format json' option to get the full path to the package file.
+
+Java (jar)
+==========
+Total: 8 (UNKNOWN: 1, LOW: 1, MEDIUM: 5, HIGH: 1, CRITICAL: 0)
+
++---------------------------------------------+------------------+----------+-------------------+--------------------------------+---------------------------------------+
+|                   LIBRARY                   | VULNERABILITY ID | SEVERITY | INSTALLED VERSION |         FIXED VERSION          |                 TITLE                 |
++---------------------------------------------+------------------+----------+-------------------+--------------------------------+---------------------------------------+
+| ch.qos.logback:logback-core                 | CVE-2021-42550   | MEDIUM   | 1.2.3             |                                | logback: remote code execution        |
+| (graphhopper.jar)                           |                  |          |                   |                                | through JNDI call from within         |
+|                                             |                  |          |                   |                                | its configuration file...             |
+|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2021-42550 |
++---------------------------------------------+------------------+----------+-------------------+--------------------------------+---------------------------------------+
+| com.fasterxml.jackson.core:jackson-databind | CVE-2020-36518   | HIGH     | 2.10.5.1          | 2.12.6.1, 2.13.2.1             | jackson-databind: denial of service   |
+| (graphhopper.jar)                           |                  |          |                   |                                | via a large depth of nested objects   |
+|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-36518 |
++---------------------------------------------+------------------+----------+-------------------+--------------------------------+---------------------------------------+
+| com.google.protobuf:protobuf-java           | CVE-2021-22569   | MEDIUM   | 3.11.4            | 3.16.1, 3.18.2, 3.19.2         | protobuf-java: potential DoS in the   |
+| (graphhopper.jar)                           |                  |          |                   |                                | parsing procedure for binary data     |
+|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2021-22569 |
++                                             +------------------+----------+                   +                                +---------------------------------------+
+|                                             | GMS-2022-5       | UNKNOWN  |                   |                                | A potential Denial of Service         |
+|                                             |                  |          |                   |                                | issue in protobuf-java                |
++---------------------------------------------+------------------+----------+-------------------+--------------------------------+---------------------------------------+
+| org.eclipse.jetty:jetty-server              | CVE-2021-34428   | LOW      | 9.4.39.v20210325  | 9.4.40.v20210413, 10.0.3,      | jetty: SessionListener can            |
+| (graphhopper.jar)                           |                  |          |                   | 11.0.3                         | prevent a session from being          |
+|                                             |                  |          |                   |                                | invalidated breaking logout           |
+|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2021-34428 |
++---------------------------------------------+------------------+----------+                   +--------------------------------+---------------------------------------+
+| org.eclipse.jetty:jetty-servlets            | CVE-2021-28169   | MEDIUM   |                   | 9.4.41.v20210516, 10.0.3,      | jetty: requests to the                |
+| (graphhopper.jar)                           |                  |          |                   | 11.0.3                         | ConcatServlet and WelcomeFilter       |
+|                                             |                  |          |                   |                                | are able to access protected...       |
+|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2021-28169 |
++---------------------------------------------+------------------+          +-------------------+--------------------------------+---------------------------------------+
+| org.glassfish.jersey.core:jersey-common     | CVE-2021-28168   |          |              2.33 | 2.34, 3.0.2                    | jersey: Local information disclosure  |
+| (graphhopper.jar)                           |                  |          |                   |                                | via system temporary directory        |
+|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2021-28168 |
++---------------------------------------------+------------------+          +-------------------+--------------------------------+---------------------------------------+
+| org.glassfish:jakarta.el                    | CVE-2021-28170   |          | 3.0.3             |                                | jakarta-el: ELParserTokenManager      |
+| (graphhopper.jar)                           |                  |          |                   |                                | enables invalid EL                    |
+|                                             |                  |          |                   |                                | expressions to be evaluate            |
+|                                             |                  |          |                   |                                | -->avd.aquasec.com/nvd/cve-2021-28170 |
++---------------------------------------------+------------------+----------+-------------------+--------------------------------+---------------------------------------+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* bump Graphhopper version from `4.0` to `5.0`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
