### PR TITLE
fix(delivery-dispatch/app/sameday): planningIDs unique; filter non-cached locations

### DIFF
--- a/prototype/dispatch/delivery-dispatch/apps/sameday-directpudo/src/main/java/dev/aws/proto/apps/sameday/directpudo/Order.java
+++ b/prototype/dispatch/delivery-dispatch/apps/sameday-directpudo/src/main/java/dev/aws/proto/apps/sameday/directpudo/Order.java
@@ -37,6 +37,10 @@ public class Order extends dev.aws.proto.core.Order {
     public static class Origin extends CoordinateWithId {
         private int preparationTimeInMins;
         private List<String> tags;
+
+        public String toString() {
+            return super.toString() + " | prepTime=" + preparationTimeInMins;
+        }
     }
 
     @Data

--- a/prototype/dispatch/delivery-dispatch/apps/sameday-directpudo/src/main/java/dev/aws/proto/apps/sameday/directpudo/data/DdbHubService.java
+++ b/prototype/dispatch/delivery-dispatch/apps/sameday-directpudo/src/main/java/dev/aws/proto/apps/sameday/directpudo/data/DdbHubService.java
@@ -87,7 +87,7 @@ public class DdbHubService extends DdbServiceBase {
         for (Map<String, AttributeValue> dbItem : dbItems) {
             try {
                 Coordinate coord = objectMapper.treeToValue(JsonAttributeValueUtil.fromAttributeValue(dbItem.get("coordinate")), Coordinate.class);
-                hubs.add(new PlanningHub(dbItem.get("ID").s(), dbItem.get("name").s(), coord));
+                hubs.add(new PlanningHub(dbItem.get("ID").s(), dbItem.get("name").s(), coord, Integer.parseInt(dbItem.get("numOfVehicles").n())));
             } catch (JsonProcessingException e) {
                 logger.error("Error parsing ddbItem :: coordinate", e);
             }

--- a/prototype/dispatch/delivery-dispatch/apps/sameday-directpudo/src/main/java/dev/aws/proto/apps/sameday/directpudo/domain/planning/PlanningHub.java
+++ b/prototype/dispatch/delivery-dispatch/apps/sameday-directpudo/src/main/java/dev/aws/proto/apps/sameday/directpudo/domain/planning/PlanningHub.java
@@ -28,15 +28,17 @@ import lombok.Setter;
 public class PlanningHub extends PlanningBase<String> {
     private String name;
     private Coordinate coordinate;
+    private int numOfVehicles;
 
-    public PlanningHub(String id, String name, Coordinate coordinate) {
+    public PlanningHub(String id, String name, Coordinate coordinate, int numOfVehicles) {
         this.id = id;
         this.name = name;
         this.coordinate = coordinate;
+        this.numOfVehicles = numOfVehicles;
     }
 
     @Override
     public String toString() {
-        return name + " " + coordinate;
+        return name + " | vehicles = " + numOfVehicles + " | " + coordinate;
     }
 }

--- a/prototype/dispatch/delivery-dispatch/apps/sameday-directpudo/src/main/java/dev/aws/proto/apps/sameday/directpudo/planner/solution/SolutionConsumer.java
+++ b/prototype/dispatch/delivery-dispatch/apps/sameday-directpudo/src/main/java/dev/aws/proto/apps/sameday/directpudo/planner/solution/SolutionConsumer.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 public class SolutionConsumer {
@@ -196,7 +197,13 @@ public class SolutionConsumer {
     public static void logSolution(DispatchSolution solution) {
         logger.debug("[{}] solution score: {}", solution.getId(), solution.getScore());
 
+        AtomicInteger notAssignedVehicleCnt = new AtomicInteger(0);
+
         solution.getPlanningVehicles().forEach(vehicle -> {
+            if (vehicle.getNextPlanningVisit() == null) {
+                notAssignedVehicleCnt.incrementAndGet();
+                return;
+            }
 
             logger.debug("vehicle[{}] :: [visits = {}] :: location {}", vehicle.getId(), vehicle.chainLength(), vehicle.getLocation().getCoordinate());
 
@@ -204,10 +211,6 @@ public class SolutionConsumer {
             points.add(vehicle.getLocation().getCoordinate());
 
             PlanningVisit visit = vehicle.getNextPlanningVisit();
-            if (visit == null) {
-                logger.debug("\t-- NO visits assigned");
-            }
-
             while (visit != null) {
                 logger.debug("\t{}", visit);
                 points.add(visit.getLocation().getCoordinate());
@@ -223,9 +226,9 @@ public class SolutionConsumer {
             StringBuilder sb = new StringBuilder();
             logger.debug("");
             logger.debug("\tPoints encoded: {}", pointsEncoded);
-            logger.debug("\tPoints: {}", coordsStr);
-
-
+//            logger.debug("\tPoints: {}", coordsStr);
         });
+
+        logger.debug("Number of vehicles not assigned: {}", notAssignedVehicleCnt.get());
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* filter orders from the request that have pikcup/dropoff locations that are outside the cached area
* fix `planningIDs must be unique` error

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
