### PR TITLE
Fix index idx-instant-delivery-provider-orders-jobid

### DIFF
--- a/packages/@prototype/data-storage/src/DataStoragePersistent/InstantDeliveryDataStorage/index.ts
+++ b/packages/@prototype/data-storage/src/DataStoragePersistent/InstantDeliveryDataStorage/index.ts
@@ -93,7 +93,7 @@ export class InstantDeliveryDataStorage extends DataStorage<DataStorageProps> {
 		instantDeliveryProviderOrders.addGlobalSecondaryIndex({
 			indexName: instantDeliveryProviderOrdersJobIdIndex,
 			partitionKey: {
-				name: 'jobid',
+				name: 'jobId',
 				type: ddb.AttributeType.STRING,
 			},
 		})


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
When creating the idx-instant-delivery-provider-orders-jobid index, the partitionKey uses 'jobid' name (all lower case) when the name should actually be 'jobId', with an upper case "i"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
