### PR TITLE
feat(order-orchestration): delivery type routing

### DIFF
--- a/packages/@prototype/data-storage/src/DataStoragePersistent/RootDataStorage/seeder/demographic-area-provider-engine.ts
+++ b/packages/@prototype/data-storage/src/DataStoragePersistent/RootDataStorage/seeder/demographic-area-provider-engine.ts
@@ -137,6 +137,13 @@ export class DatabaseSeeder extends Construct {
 				conditions: {
 					any: [
 						{
+							fact: 'payload',
+							operator: 'equal',
+							value: 'instant',
+							path: '$.deliveryType',
+							priority: 500,
+						},
+						{
 							all: [
 								{
 									fact: 'get-percentage',
@@ -188,6 +195,13 @@ export class DatabaseSeeder extends Construct {
 				name: 'SameDayDeliveryProvider',
 				conditions: {
 					any: [
+						{
+							fact: 'payload',
+							operator: 'equal',
+							value: 'same-day',
+							path: '$.deliveryType',
+							priority: 500,
+						},
 						{
 							all: [
 								{

--- a/prototype/simulator/container/src/destination/destination.js
+++ b/prototype/simulator/container/src/destination/destination.js
@@ -182,7 +182,9 @@ class Destination {
 			}
 		}
 
-		return undefined
+		return {
+			deliveryType: 'instant',
+		}
 	}
 
 	async refreshToken (that) {


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:*

- update simulator to send `deliveryType` also for the default provider (eg. instant delivery)
- update default configuration to route orders based on the delivery type with higher priority 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
