### PR TITLE
fix(rule-engine): fix demographic area settings

### DIFF
--- a/packages/@prototype/data-storage/src/DataStoragePersistent/RootDataStorage/seeder/demographic-area-provider-engine.ts
+++ b/packages/@prototype/data-storage/src/DataStoragePersistent/RootDataStorage/seeder/demographic-area-provider-engine.ts
@@ -45,24 +45,8 @@ export class DatabaseSeeder extends Construct {
 						{
 							fact: 'get-percentage',
 							operator: 'lessThanInclusive',
-							value: 10,
+							value: 50,
 							priority: 10,
-						},
-						{
-							all: [
-								{
-									fact: 'get-date',
-									operator: 'includes',
-									value: '12-25',
-									priority: 20,
-								},
-								{
-									fact: 'get-percentage',
-									operator: 'lessThanInclusive',
-									value: 15,
-									priority: 20,
-								},
-							],
 						},
 						{
 							fact: 'origin',
@@ -84,44 +68,19 @@ export class DatabaseSeeder extends Construct {
 			{
 				name: 'WebhookProvider',
 				conditions: {
-					any: [{
-						all: [
-							{
-								fact: 'get-percentage',
-								operator: 'greaterThan',
-								value: 10,
-								priority: 10,
-							},
-							{
-								fact: 'get-percentage',
-								operator: 'lessThanInclusive',
-								value: 30,
-								priority: 10,
-							},
-						],
-					},
-					{
-						all: [
-							{
-								fact: 'get-date',
-								operator: 'includes',
-								value: '12-25',
-								priority: 20,
-							},
-							{
-								fact: 'get-percentage',
-								operator: 'greaterThan',
-								value: 15,
-								priority: 20,
-							},
-							{
-								fact: 'get-percentage',
-								operator: 'lessThanInclusive',
-								value: 35,
-								priority: 20,
-							},
-						],
-					},
+					any: [
+						{
+							fact: 'get-percentage',
+							operator: 'greaterThan',
+							value: 50,
+							priority: 10,
+						},
+						{
+							fact: 'get-percentage',
+							operator: 'lessThanInclusive',
+							value: 100,
+							priority: 10,
+						},
 					],
 				},
 				event: {
@@ -135,51 +94,13 @@ export class DatabaseSeeder extends Construct {
 			{
 				name: 'InstantDeliveryProvider',
 				conditions: {
-					any: [
+					all: [
 						{
 							fact: 'payload',
 							operator: 'equal',
 							value: 'instant',
 							path: '$.deliveryType',
 							priority: 500,
-						},
-						{
-							all: [
-								{
-									fact: 'get-percentage',
-									operator: 'greaterThan',
-									value: 30,
-									priority: 10,
-								},
-								{
-									fact: 'get-percentage',
-									operator: 'lessThanInclusive',
-									value: 65,
-									priority: 10,
-								},
-							],
-						},
-						{
-							all: [
-								{
-									fact: 'get-date',
-									operator: 'includes',
-									value: '12-25',
-									priority: 20,
-								},
-								{
-									fact: 'get-percentage',
-									operator: 'greaterThan',
-									value: 35,
-									priority: 20,
-								},
-								{
-									fact: 'get-percentage',
-									operator: 'lessThanInclusive',
-									value: 65,
-									priority: 20,
-								},
-							],
 						},
 					],
 				},
@@ -194,51 +115,13 @@ export class DatabaseSeeder extends Construct {
 			{
 				name: 'SameDayDeliveryProvider',
 				conditions: {
-					any: [
+					all: [
 						{
 							fact: 'payload',
 							operator: 'equal',
 							value: 'same-day',
 							path: '$.deliveryType',
-							priority: 500,
-						},
-						{
-							all: [
-								{
-									fact: 'get-percentage',
-									operator: 'greaterThanInclusive',
-									value: 65,
-									priority: 10,
-								},
-								{
-									fact: 'get-percentage',
-									operator: 'lessThanInclusive',
-									value: 100,
-									priority: 10,
-								},
-							],
-						},
-						{
-							all: [
-								{
-									fact: 'get-date',
-									operator: 'includes',
-									value: '12-25',
-									priority: 20,
-								},
-								{
-									fact: 'get-percentage',
-									operator: 'greaterThan',
-									value: 65,
-									priority: 20,
-								},
-								{
-									fact: 'get-percentage',
-									operator: 'lessThanInclusive',
-									value: 100,
-									priority: 20,
-								},
-							],
+							priority: 600,
 						},
 					],
 				},

--- a/packages/@prototype/order-manager/src/OrderManager/ProviderRuleEngine/@lambda/src/commands/cancelOrderFromProvider.js
+++ b/packages/@prototype/order-manager/src/OrderManager/ProviderRuleEngine/@lambda/src/commands/cancelOrderFromProvider.js
@@ -53,10 +53,10 @@ const execute = async (payload) => {
 			result: res.data,
 		}
 	} catch (err) {
-		console.error('Error cancelling the order to the provider')
+		console.error(`Error cancelling the order to the provider ${providerName}`)
 		console.error(err)
 
-		throw new Error('Error cancelling the order to the provider')
+		throw new Error(`Error cancelling the order to the provider ${providerName}`)
 	}
 }
 

--- a/packages/@prototype/order-manager/src/OrderManager/ProviderRuleEngine/@lambda/src/commands/sendToProvider.js
+++ b/packages/@prototype/order-manager/src/OrderManager/ProviderRuleEngine/@lambda/src/commands/sendToProvider.js
@@ -53,11 +53,11 @@ const execute = async (payload) => {
 			result: res.data,
 		}
 	} catch (err) {
-		console.error('Error sending the order to the provider')
+		console.error(`Error sending the order to the provider: ${providerName}`)
 		console.error(err)
 
 		// handled by the step function
-		throw new Error('Error sending the order to the provider')
+		throw new Error(`Error sending the order to the provider: ${providerName}`)
 	}
 }
 


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:*
- fix demographic area settings to remove ambiguity on the type of results returned by the provider rule engine. In the previous iteration was possible to have both `instant` and `same-day` delivery as output (with the second one being used if the first doesn't return a result), which lead to some inconsistency on the way the package is handled by the provider. While this _could_ be possible in some instances, for this sample we'll try to handle the incoming order with either `instant` or `same-day` provider (and, possibly, handle it with external providers to simulate some underlying issues on original provider)
- added some extra information in the logs to help further debugging


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
