### PR TITLE
feat: automated deployment

### DIFF
--- a/packages/@prototype/external-provider-mock/src/ExternalWebhookProviderStack/WebhookInvoker/index.ts
+++ b/packages/@prototype/external-provider-mock/src/ExternalWebhookProviderStack/WebhookInvoker/index.ts
@@ -20,7 +20,7 @@ import { DeclaredLambdaFunction } from '@aws-play/cdk-lambda'
 import { namespaced } from '@aws-play/cdk-core'
 
 interface ExternalWebhookInvokerStackProps {
-	readonly exampleWebhookApiSecretName: string
+	readonly callbackApiKeySecretName: string
 	readonly externalOrderFinalisedIndex: string
 	readonly externalOrderTable: ddb.ITable
 }
@@ -31,11 +31,11 @@ export class ExternalWebhookInvokerStack extends Construct {
 
 		const {
 			externalOrderTable,
-			exampleWebhookApiSecretName,
+			callbackApiKeySecretName,
 			externalOrderFinalisedIndex,
 		} = props
 
-		const exampleWebhookProviderSecret = secretsmanager.Secret.fromSecretNameV2(scope, 'ExternalWebhookSecret', exampleWebhookApiSecretName)
+		const exampleWebhookProviderSecret = secretsmanager.Secret.fromSecretNameV2(scope, 'ExternalWebhookSecret', callbackApiKeySecretName)
 
 		const webhookInvoker = new lambda.Function(this, 'ExternalWebhookInvoker', {
 			functionName: namespaced(this, 'WebhookInvoker'),
@@ -46,7 +46,7 @@ export class ExternalWebhookInvokerStack extends Construct {
 			architecture: lambda.Architecture.ARM_64,
 			timeout: Duration.minutes(1),
 			environment: {
-				EXAMPLE_WEBHOOK_SECRET: exampleWebhookApiSecretName,
+				EXAMPLE_WEBHOOK_SECRET: callbackApiKeySecretName,
 				EXTERNAL_ORDER_TABLE: externalOrderTable.tableName,
 				EXTERNAL_ORDER_FINALISED_INDEX: externalOrderFinalisedIndex,
 			},

--- a/packages/@prototype/order-manager/src/OrderManager/ProviderRuleEngine/index.ts
+++ b/packages/@prototype/order-manager/src/OrderManager/ProviderRuleEngine/index.ts
@@ -27,7 +27,7 @@ interface Environment extends DeclaredLambdaEnvironment {
 interface Dependencies extends DeclaredLambdaDependencies {
 	readonly demographicAreaProviderEngineSettings: ddb.ITable
 	readonly providersConfig: { [key: string]: any, }
-	readonly providerApiUrls: {[key: string]: apigw.RestApi, }
+	readonly providerApiUrls: Record<string, string>
 }
 
 type TDeclaredProps = DeclaredLambdaProps<Environment, Dependencies>
@@ -55,13 +55,13 @@ export class ProviderRuleEngineLambda extends DeclaredLambdaFunction<Environment
 				PROVIDERS: Object.keys(providersConfig).join(','),
 				DEMOGRAPHIC_AREA_SETTINGS_TABLE: demographicAreaProviderEngineSettings.tableName,
 				EXAMPLE_POLLING_PROVIDER_SECRET_NAME: providersConfig.ExamplePollingProvider.apiKeySecretName,
-				EXAMPLE_POLLING_PROVIDER_URL: providerApiUrls.ExamplePollingProvider.url,
+				EXAMPLE_POLLING_PROVIDER_URL: providerApiUrls.ExamplePollingProvider,
 				EXAMPLE_WEBHOOK_PROVIDER_SECRET_NAME: providersConfig.ExampleWebhookProvider.apiKeySecretName,
-				EXAMPLE_WEBHOOK_PROVIDER_URL: providerApiUrls.ExampleWebhookProvider.url,
+				EXAMPLE_WEBHOOK_PROVIDER_URL: providerApiUrls.ExampleWebhookProvider,
 				INSTANT_DELIVERY_PROVIDER_SECRET_NAME: providersConfig.InstantDeliveryProvider.apiKeySecretName,
-				INSTANT_DELIVERY_PROVIDER_URL: providerApiUrls.InstantDeliveryProvider.url,
+				INSTANT_DELIVERY_PROVIDER_URL: providerApiUrls.InstantDeliveryProvider,
 				SAME_DAY_DELIVERY_PROVIDER_SECRET_NAME: providersConfig.SameDayDeliveryProvider.apiKeySecretName,
-				SAME_DAY_DELIVERY_PROVIDER_URL: providerApiUrls.SameDayDeliveryProvider.url,
+				SAME_DAY_DELIVERY_PROVIDER_URL: providerApiUrls.SameDayDeliveryProvider,
 			},
 			initialPolicy: [
 				new iam.PolicyStatement({

--- a/packages/@prototype/order-manager/src/OrderManager/index.ts
+++ b/packages/@prototype/order-manager/src/OrderManager/index.ts
@@ -30,7 +30,7 @@ export interface OrderManagerStackProps {
 	readonly demographicAreaProviderEngineSettings: ddb.ITable
 	readonly orderTable: ddb.ITable
 	readonly providersConfig: { [key: string]: any, }
-	readonly providerApiUrls: {[key: string]: apigw.RestApi, }
+	readonly providerApiUrls: Record<string, string>
 	readonly privateVpc: ec2.IVpc
 	readonly vpcNetworking: Networking
 	readonly memoryDBCluster: MemoryDBCluster

--- a/prototype/infra/bin/dev-infra.ts
+++ b/prototype/infra/bin/dev-infra.ts
@@ -28,6 +28,14 @@ import { CloudFrontWebACLStack } from '../lib/stack/root/CloudFrontWebACLStack'
 
 const app = new App()
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const externalProvider = new ExternalProviderStack(app, 'ExternalProviderStack-Mock', {
+	stackName: 'ExternalProviderStack-Mock',
+	description: 'External Provider Mock Stack',
+	...config,
+	namespace: 'external',
+})
+
 const persistentBackendStack = new PersistentBackendStack(app, 'Dev-PersistentBackend', {
 	stackName: 'Dev-PersistentBackend',
 	description: 'Persistent Stack for RETAIN resources',
@@ -40,6 +48,10 @@ const backendStack = new BackendStack(app, 'Dev-Backend', {
 	persistent: persistentBackendStack,
 	...config,
 })
+
+// add explicit dependency: external providers must be created before this
+// so the ssm params are already in place for the external api's urls
+backendStack.addDependency(externalProvider)
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const debugStack = new DebugStack(app, 'Dev-DebugStack', {
@@ -85,14 +97,6 @@ const simulatorMainStack = new SimulatorMainStack(app, 'Simulator-Backend', {
 	...config,
 	simulatorPersistent: simulatorPersistentStack,
 	namespace: simulatorNamespace,
-})
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const externalProver = new ExternalProviderStack(app, 'ExternalProviderStack-Mock', {
-	stackName: 'ExternalProviderStack-Mock',
-	description: 'External Provider Mock Stack',
-	...config,
-	namespace: 'external',
 })
 
 Tags.of(app).add('proto:deployment:id', `${config.namespace}-lastmiledelivery-deployment`)

--- a/prototype/infra/config/default.yaml
+++ b/prototype/infra/config/default.yaml
@@ -229,17 +229,22 @@ webhookProviderSettings: {}
 # EXTERNAL provider config
 # * key: the _name_ of the external provider
 # * value:
-#     * apiKeySecretName: the entry key in SecretsManager wherre the API key is stored
-#     * url: the endpoint of the external provider
+#     * apiKeySecretName: the entry key in SecretsManager where the API key is stored
+#     * apiUrlParameterStoreKey: the entry key in SSM ParameterStore where the API URL is stored
+#     * type: the type of the provider: polling-provider | webhook-provider\
+#     * callbackProviderName: [only for mock/external webhook provider] the name of the internal provider to callback to
 externalProviderConfig:
   # example polling provider
   MockPollingProvider:
     apiKeySecretName: ExternalMockPollingProviderApiKeySecret
-    url: https://XXXXXXXXXX.execute-api.ap-southeast-1.amazonaws.com/prod
+    apiUrlParameterStoreKey: /Hyperlocal/ExternalProvider/MockPollingProvider/Url
+    type: 'polling-provider'
   # example webhook provider
   MockWebhookProvider:
     apiKeySecretName: ExternalMockWebhookProviderApiKeySecret
-    url: https://XXXXXXXXXX.execute-api.ap-southeast-1.amazonaws.com/prod
+    apiUrlParameterStoreKey: /Hyperlocal/ExternalProvider/MockWebhookProvider/Url
+    type: 'webhook-provider'
+    callbackProviderName: 'ExampleWebhookProvider'
 
 # providers in the system (non-external)
 # * key: the name of the provider

--- a/prototype/infra/lib/stack/nested/CustomResourcesStack/index.ts
+++ b/prototype/infra/lib/stack/nested/CustomResourcesStack/index.ts
@@ -62,13 +62,13 @@ export class CustomResourcesStack extends NestedStack {
 
 		let apiKeySecretNameList: ApiKeySecretConfigItem[] = [
 			{
-				keyArn: providerNestedStack.examplePollingProvider.apiKey.keyArn,
-				keyId: providerNestedStack.examplePollingProvider.apiKey.keyId,
+				keyArn: providerNestedStack.pollingProviders.ExamplePollingProvider.apiKey.keyArn,
+				keyId: providerNestedStack.pollingProviders.ExamplePollingProvider.apiKey.keyId,
 				secret: providersConfig.ExamplePollingProvider.apiKeySecretName,
 			},
 			{
-				keyArn: providerNestedStack.exampleWebhookProvider.apiKey.keyArn,
-				keyId: providerNestedStack.exampleWebhookProvider.apiKey.keyId,
+				keyArn: providerNestedStack.webhookProviders.ExampleWebhookProvider.apiKey.keyArn,
+				keyId: providerNestedStack.webhookProviders.ExampleWebhookProvider.apiKey.keyId,
 				secret: providersConfig.ExampleWebhookProvider.apiKeySecretName,
 			},
 			{

--- a/prototype/infra/lib/stack/nested/OrderOrchestrationStack/index.ts
+++ b/prototype/infra/lib/stack/nested/OrderOrchestrationStack/index.ts
@@ -27,7 +27,7 @@ export interface OrderOrchestrationStackProps extends NestedStackProps {
 	readonly orderTable: ddb.ITable
 	readonly eventBus: events.EventBus
 	readonly providersConfig: { [key: string]: any, }
-	readonly providerApiUrls: {[key: string]: api.RestApi, }
+	readonly providerApiUrls: Record<string, string>
 	readonly vpc: ec2.IVpc
 	readonly vpcNetworking: net.Networking
 	readonly lambdaLayers: { [key: string]: lambda.ILayerVersion, }

--- a/prototype/infra/lib/stack/root/BackendStack/index.ts
+++ b/prototype/infra/lib/stack/root/BackendStack/index.ts
@@ -27,7 +27,7 @@ import { AppConfigNestedStack } from '@prototype/appconfig'
 import { ProviderStack } from '../../nested/ProviderStack'
 import { CustomResourcesStack } from '../../nested/CustomResourcesStack'
 import { IoTStack } from '@prototype/iot-ingestion'
-import { ExternalProviderType } from '../ExternalProviderStack'
+import { ExternalProviderEntry } from '../ExternalProviderStack'
 import { DispatcherStack } from '../../nested/DispatcherStack'
 
 export interface BackendStackProps extends StackProps {
@@ -39,10 +39,7 @@ export interface BackendStackProps extends StackProps {
 	readonly pollingProviderSettings: { [key: string]: string | number, }
 	readonly webhookProviderSettings: { [key: string]: string | number, }
 	readonly providersConfig: { [key: string]: any, }
-	readonly externalProviderConfig: {
-		MockPollingProvider: ExternalProviderType
-		MockWebhookProvider: ExternalProviderType
-	}
+	readonly externalProviderConfig: Record<string, ExternalProviderEntry>
 	readonly instantDeliveryProviderSettings: { [key: string]: string | number | boolean, }
 	readonly sameDayDeliveryProviderSettings: { [key: string]: string | number | boolean, }
 	readonly orderManagerSettings: { [key: string]: string | number | boolean, }
@@ -251,10 +248,10 @@ export class BackendStack extends Stack {
 			memoryDBCluster: liveDataCache.memoryDBCluster,
 			orderManagerSettings,
 			providerApiUrls: {
-				InstantDeliveryProvider: providerNestedStack.instantDeliveryWebhookProvider.apiGwInstance,
-				SameDayDeliveryProvider: providerNestedStack.sameDayDeliveryWebhookProvider.apiGwInstance,
-				ExampleWebhookProvider: providerNestedStack.exampleWebhookProvider.apiGwInstance,
-				ExamplePollingProvider: providerNestedStack.examplePollingProvider.apiGwInstance,
+				InstantDeliveryProvider: providerNestedStack.instantDeliveryWebhookProvider.apiGwInstance.url,
+				SameDayDeliveryProvider: providerNestedStack.sameDayDeliveryWebhookProvider.apiGwInstance.url,
+				ExampleWebhookProvider: providerNestedStack.webhookProviders.ExampleWebhookProvider.apiGwInstance.url,
+				ExamplePollingProvider: providerNestedStack.pollingProviders.ExamplePollingProvider.apiGwInstance.url,
 			},
 		})
 

--- a/prototype/infra/package.json
+++ b/prototype/infra/package.json
@@ -20,6 +20,8 @@
     "dev:deploy": "yarn dev:cdk deploy --require-approval never Dev-Backend",
     "dev:deploy:externalmock": "yarn dev:cdk deploy --require-approval never ExternalProviderStack-Mock",
     "dev:deploy:sim": "yarn dev:cdk deploy --require-approval never Simulator-Backend",
+    "dev:deploy:sim-only": "yarn dev:cdk deploy --require-approval never --app cdk.out.dev Simulator-Persistent Simulator-Backend",
+    "dev:deploy:simbackend-only": "yarn dev:cdk deploy --require-approval never --app cdk.out.dev Simulator-Backend",
     "dev:deploy:all": "yarn dev:cdk deploy --require-approval never '*'",
     "dev:DESTROY:backend": "yarn dev:cdk destroy Dev-Backend",
     "dev:DESTROY:simbackend": "yarn dev:cdk destroy Simulator-Backend",

--- a/reports/cfn-nag-report.json
+++ b/reports/cfn-nag-report.json
@@ -1,5 +1,286 @@
 [
   {
+    "filename": "./cdk.out.dev/CloudFrontWebACL.template.json",
+    "file_results": {
+      "failure_count": 0,
+      "violations": [
+        {
+          "id": "W12",
+          "name": "IamPolicyWildcardResourceRule",
+          "type": "WARN",
+          "message": "IAM policy should not allow * resource",
+          "logical_resource_ids": [
+            "storeWafArnInSSMParamInRegionCustomResourcePolicy03D653FA"
+          ],
+          "line_numbers": [
+            69
+          ],
+          "element_types": [
+            "resource"
+          ]
+        },
+        {
+          "id": "W58",
+          "name": "LambdaFunctionCloudWatchLogsRule",
+          "type": "WARN",
+          "message": "Lambda functions require permission to write CloudWatch Logs",
+          "logical_resource_ids": [
+            "AWS679f53fac002430cb0da5b7982bd22872D164C4C"
+          ],
+          "line_numbers": [
+            174
+          ],
+          "element_types": [
+            "resource"
+          ]
+        },
+        {
+          "id": "W89",
+          "name": "LambdaFunctionInsideVPCRule",
+          "type": "WARN",
+          "message": "Lambda functions should be deployed inside a VPC",
+          "logical_resource_ids": [
+            "AWS679f53fac002430cb0da5b7982bd22872D164C4C"
+          ],
+          "line_numbers": [
+            174
+          ],
+          "element_types": [
+            "resource"
+          ]
+        },
+        {
+          "id": "W92",
+          "name": "LambdaFunctionReservedConcurrentExecutionsRule",
+          "type": "WARN",
+          "message": "Lambda functions should define ReservedConcurrentExecutions to reserve simultaneous executions",
+          "logical_resource_ids": [
+            "AWS679f53fac002430cb0da5b7982bd22872D164C4C"
+          ],
+          "line_numbers": [
+            174
+          ],
+          "element_types": [
+            "resource"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "filename": "./cdk.out.dev/Dev-Backend.template.json",
+    "file_results": {
+      "failure_count": 0,
+      "violations": [
+        {
+          "id": "W12",
+          "name": "IamPolicyWildcardResourceRule",
+          "type": "WARN",
+          "message": "IAM policy should not allow * resource",
+          "logical_resource_ids": [
+            "IoTEndpointBackendStackCustomResourcePolicy80EB5EED"
+          ],
+          "line_numbers": [
+            5
+          ],
+          "element_types": [
+            "resource"
+          ]
+        },
+        {
+          "id": "W58",
+          "name": "LambdaFunctionCloudWatchLogsRule",
+          "type": "WARN",
+          "message": "Lambda functions require permission to write CloudWatch Logs",
+          "logical_resource_ids": [
+            "AWS679f53fac002430cb0da5b7982bd22872D164C4C"
+          ],
+          "line_numbers": [
+            90
+          ],
+          "element_types": [
+            "resource"
+          ]
+        },
+        {
+          "id": "W89",
+          "name": "LambdaFunctionInsideVPCRule",
+          "type": "WARN",
+          "message": "Lambda functions should be deployed inside a VPC",
+          "logical_resource_ids": [
+            "AWS679f53fac002430cb0da5b7982bd22872D164C4C"
+          ],
+          "line_numbers": [
+            90
+          ],
+          "element_types": [
+            "resource"
+          ]
+        },
+        {
+          "id": "W92",
+          "name": "LambdaFunctionReservedConcurrentExecutionsRule",
+          "type": "WARN",
+          "message": "Lambda functions should define ReservedConcurrentExecutions to reserve simultaneous executions",
+          "logical_resource_ids": [
+            "AWS679f53fac002430cb0da5b7982bd22872D164C4C"
+          ],
+          "line_numbers": [
+            90
+          ],
+          "element_types": [
+            "resource"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "filename": "./cdk.out.dev/Dev-DebugStack.template.json",
+    "file_results": {
+      "failure_count": 0,
+      "violations": [
+
+      ]
+    }
+  },
+  {
+    "filename": "./cdk.out.dev/Dev-PersistentBackend.template.json",
+    "file_results": {
+      "failure_count": 0,
+      "violations": [
+        {
+          "id": "W33",
+          "name": "EC2SubnetMapPublicIpOnLaunchRule",
+          "type": "WARN",
+          "message": "EC2 Subnet should not have MapPublicIpOnLaunch set to true",
+          "logical_resource_ids": [
+            "VpcPersistentVpcdevprotopublicSubnet1SubnetC72F26B2",
+            "VpcPersistentVpcdevprotopublicSubnet2Subnet81CE9099",
+            "VpcPersistentVpcdevprotopublicSubnet3Subnet509A8694"
+          ],
+          "line_numbers": [
+            29,
+            160,
+            245
+          ],
+          "element_types": [
+            "resource",
+            "resource",
+            "resource"
+          ]
+        },
+        {
+          "id": "W60",
+          "name": "VpcHasFlowLogRule",
+          "type": "WARN",
+          "message": "VPC should have a flow log attached",
+          "logical_resource_ids": [
+            "VpcPersistentVpc914608BE"
+          ],
+          "line_numbers": [
+            5
+          ],
+          "element_types": [
+            "resource"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "filename": "./cdk.out.dev/DevBackendAppConfigNestedStack0AB9D01F.nested.template.json",
+    "file_results": {
+      "failure_count": 0,
+      "violations": [
+        {
+          "id": "W12",
+          "name": "IamPolicyWildcardResourceRule",
+          "type": "WARN",
+          "message": "IAM policy should not allow * resource",
+          "logical_resource_ids": [
+            "DeploymentHandlerLambdaServiceRoleDefaultPolicy5C7DE2FF"
+          ],
+          "line_numbers": [
+            301
+          ],
+          "element_types": [
+            "resource"
+          ]
+        },
+        {
+          "id": "W58",
+          "name": "LambdaFunctionCloudWatchLogsRule",
+          "type": "WARN",
+          "message": "Lambda functions require permission to write CloudWatch Logs",
+          "logical_resource_ids": [
+            "DeploymentHandlerLambda04B758EE",
+            "AWS679f53fac002430cb0da5b7982bd22872D164C4C"
+          ],
+          "line_numbers": [
+            390,
+            651
+          ],
+          "element_types": [
+            "resource",
+            "resource"
+          ]
+        },
+        {
+          "id": "W89",
+          "name": "LambdaFunctionInsideVPCRule",
+          "type": "WARN",
+          "message": "Lambda functions should be deployed inside a VPC",
+          "logical_resource_ids": [
+            "DeploymentHandlerLambda04B758EE",
+            "AWS679f53fac002430cb0da5b7982bd22872D164C4C"
+          ],
+          "line_numbers": [
+            390,
+            651
+          ],
+          "element_types": [
+            "resource",
+            "resource"
+          ]
+        },
+        {
+          "id": "W92",
+          "name": "LambdaFunctionReservedConcurrentExecutionsRule",
+          "type": "WARN",
+          "message": "Lambda functions should define ReservedConcurrentExecutions to reserve simultaneous executions",
+          "logical_resource_ids": [
+            "DeploymentHandlerLambda04B758EE",
+            "AWS679f53fac002430cb0da5b7982bd22872D164C4C"
+          ],
+          "line_numbers": [
+            390,
+            651
+          ],
+          "element_types": [
+            "resource",
+            "resource"
+          ]
+        },
+        {
+          "id": "W35",
+          "name": "S3BucketAccessLoggingRule",
+          "type": "WARN",
+          "message": "S3 Bucket should have access logging configured",
+          "logical_resource_ids": [
+            "ConfigStorageConfigBucketA9569935"
+          ],
+          "line_numbers": [
+            131
+          ],
+          "element_types": [
+            "resource"
+          ]
+        }
+      ]
+    }
+  },
+  {
     "filename": "./cdk.out.dev/DevBackendCustomResourcesNestedStack078777DE.nested.template.json",
     "file_results": {
       "failure_count": 0,
@@ -13,7 +294,7 @@
             "ProviderSetupProviderInitialSetupLambdaServiceRoleDefaultPolicy09CBAA48"
           ],
           "line_numbers": [
-            346
+            362
           ],
           "element_types": [
             "resource"
@@ -32,9 +313,9 @@
           ],
           "line_numbers": [
             82,
-            227,
-            456,
-            596
+            243,
+            472,
+            628
           ],
           "element_types": [
             "resource",
@@ -53,8 +334,8 @@
             "ProviderSetupProviderSetupProviderframeworkonEventD18167FA"
           ],
           "line_numbers": [
-            456,
-            596
+            472,
+            628
           ],
           "element_types": [
             "resource",
@@ -74,9 +355,9 @@
           ],
           "line_numbers": [
             82,
-            227,
-            456,
-            596
+            243,
+            472,
+            628
           ],
           "element_types": [
             "resource",
@@ -219,22 +500,37 @@
     }
   },
   {
-    "filename": "./cdk.out.dev/Simulator-Backend.template.json",
+    "filename": "./cdk.out.dev/DevBackendMicroServiceNestedStackC61F3420.nested.template.json",
     "file_results": {
       "failure_count": 0,
       "violations": [
         {
-          "id": "W68",
-          "name": "ApiGatewayDeploymentUsagePlanRule",
+          "id": "W59",
+          "name": "ApiGatewayMethodAuthorizationTypeRule",
           "type": "WARN",
-          "message": "AWS::ApiGateway::Deployment resources should be associated with an AWS::ApiGateway::UsagePlan. ",
+          "message": "AWS::ApiGateway::Method should not have AuthorizationType set to 'NONE' unless it is of HttpMethod: OPTIONS.",
           "logical_resource_ids": [
-            "SimulatorRestApiDeployment7165AE7Be09d81ee7b2dd284320adec20e708e3e"
+            "GeoTrackingRestApiapigeotrackinginternaldriverlocationiddriverIdGET43641EFB",
+            "GeoTrackingRestApiapigeotrackinginternaldriverlocationqueryGET6ADEEDBC",
+            "GeoTrackingRestApiapigeotrackinginternaldriverlocationqueryPOST47790ED0",
+            "GeoTrackingRestApiapigeotrackinginternaldriverlocationpolygonpolygonIdGET6333EC74",
+            "GeoTrackingRestApiapigeotrackinginternaldriverlocationpolygonPOSTE86934E0",
+            "GeoTrackingRestApiapigeotrackinginternaldemareasettingsGET2ABAA416"
           ],
           "line_numbers": [
-            200
+            1429,
+            1594,
+            1713,
+            1935,
+            2043,
+            2208
           ],
           "element_types": [
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
             "resource"
           ]
         },
@@ -244,25 +540,10 @@
           "type": "WARN",
           "message": "AWS::ApiGateway::Stage should have the AccessLogSetting property defined.",
           "logical_resource_ids": [
-            "SimulatorRestApiDeploymentStageprod2BCF2C02"
+            "GeoTrackingRestApiDeploymentStageprod14BF27C1"
           ],
           "line_numbers": [
-            305
-          ],
-          "element_types": [
-            "resource"
-          ]
-        },
-        {
-          "id": "W64",
-          "name": "ApiGatewayStageUsagePlanRule",
-          "type": "WARN",
-          "message": "AWS::ApiGateway::Stage resources should be associated with an AWS::ApiGateway::UsagePlan. ",
-          "logical_resource_ids": [
-            "SimulatorRestApiDeploymentStageprod2BCF2C02"
-          ],
-          "line_numbers": [
-            305
+            154
           ],
           "element_types": [
             "resource"
@@ -274,31 +555,28 @@
           "type": "WARN",
           "message": "IAM policy should not allow * resource",
           "logical_resource_ids": [
-            "IoTEndpointSimulatorStackCustomResourcePolicyD5FE1C80",
-            "SimulatorManagerSimulatorManagerLambdaServiceRoleDefaultPolicy875CCB78",
-            "SimulatorManagerOriginSimulatorLambdaOriginGeneratorStepFunctionOriginGeneratorHelperServiceRoleDefaultPolicy7F7C5518",
-            "SimulatorManagerOriginSimulatorLambdaServiceRoleDefaultPolicyB9182468",
-            "SimulatorManagerOriginSimulatorLambdaOriginStatusUpdateLambdaServiceRoleDefaultPolicyC378456B",
-            "SimulatorManagerOriginSimulatorLambdaOriginEventHandlerServiceRoleDefaultPolicy70005689",
-            "SimulatorManagerDestinationSimulatorLambdaDestinationGeneratorStepFunctionDestinationGeneratorHelperServiceRoleDefaultPolicy26A5D211",
-            "SimulatorManagerDestinationSimulatorLambdaServiceRoleDefaultPolicyEC8238D5",
-            "SimulatorManagerDestinationSimulatorLambdaDestinationStatusUpdateLambdaServiceRoleDefaultPolicy876D5AC8",
-            "UpdateLambdaConfigurationl2ss8axsCustomResourcePolicy5D7939FA"
+            "GeoTrackingRestApiGetDriverLocationLambdaServiceRoleDefaultPolicy0E4F7265",
+            "GeoTrackingRestApiQueryDriversLambdaServiceRoleDefaultPolicy717BCDFA",
+            "GeoTrackingRestApiListDriversForPolygonLambdaServiceRoleDefaultPolicyBF20FE88",
+            "GeoTrackingRestApiGeofencingServiceServiceRoleDefaultPolicyD1510CE6",
+            "LambdaFunctionsStackDriverLocationCleanupLambdaServiceRoleDefaultPolicyB15EEDED",
+            "LambdaFunctionsStackDriverLocationUpdateIngestLambdaServiceRoleDefaultPolicy9CA99350",
+            "LambdaFunctionsStackDriverGeofencingLambdaServiceRoleDefaultPolicyC0DC3C47",
+            "LambdaFunctionsStackDriverStatusUpdateLambdaServiceRoleDefaultPolicy2EAF1E1C",
+            "ApiGeoTrackingGetDemAreaSettingsLambdaServiceRoleDefaultPolicy4C5CDB75"
           ],
           "line_numbers": [
-            5,
-            6352,
-            6817,
-            7801,
-            8090,
-            8289,
-            8495,
-            9469,
-            9692,
-            10957
+            2701,
+            2882,
+            3063,
+            3297,
+            3729,
+            3992,
+            4303,
+            4606,
+            5017
           ],
           "element_types": [
-            "resource",
             "resource",
             "resource",
             "resource",
@@ -316,126 +594,30 @@
           "type": "WARN",
           "message": "Lambda functions require permission to write CloudWatch Logs",
           "logical_resource_ids": [
-            "AWS679f53fac002430cb0da5b7982bd22872D164C4C",
-            "SimulatorManagerSimulatorManagerLambdaESCSStepFunctionInvokerECSTaskRunHelperF98A49C7",
-            "SimulatorManagerSimulatorManagerLambda269D5609",
-            "SimulatorManagerEventsSimulatorEventSimulatorLambda192B31F9",
-            "SimulatorManagerPolygonManagerLambdaB5FAE450",
-            "SimulatorManagerOriginSimulatorLambdaOriginGeneratorStepFunctionOriginGeneratorHelperC2BD95BD",
-            "SimulatorManagerOriginSimulatorLambdaOriginStarterStepFunctionOriginStarterHelperA28A5905",
-            "SimulatorManagerOriginSimulatorLambdaOriginEraserStepFunctionOriginEraserHelperFE478FE3",
-            "SimulatorManagerOriginSimulatorLambda669B2FA5",
-            "SimulatorManagerOriginSimulatorLambdaOriginStatusUpdateLambdaD5130653",
-            "SimulatorManagerOriginSimulatorLambdaOriginEventHandler70EF4889",
-            "SimulatorManagerDestinationSimulatorLambdaDestinationGeneratorStepFunctionDestinationGeneratorHelperD80AFFC5",
-            "SimulatorManagerDestinationSimulatorLambdaDestinationStarterStepFunctionDestinationStarterHelper6D16BE0E",
-            "SimulatorManagerDestinationSimulatorLambdaDestinationEraserStepFunctionDestinationEraserHelperEEF2F7D1",
-            "SimulatorManagerDestinationSimulatorLambdaE614D361",
-            "SimulatorManagerDestinationSimulatorLambdaDestinationStatusUpdateLambda7FD0C441",
-            "SimulatorManagerDestinationSimulatorLambdaS3PresignedUrlLambdaE6ECBCFE",
-            "SimulatorManagerOrderSimulatorLambda1D914205",
-            "SimulatorManagerStatsSimulatorLambdaStatisticsLambdaD6482994",
-            "SimulatorManagerInstantDeliveryDispatcherAssignmentQueryLambda7796E184",
-            "SimulatorManagerSameDayDeliveryDispatcherAssignmentQueryLambda00538C73"
+            "GeoTrackingRestApiGetDriverLocationLambda16797A58",
+            "GeoTrackingRestApiQueryDriversLambdaDC17E2A5",
+            "GeoTrackingRestApiListDriversForPolygonLambda2F311273",
+            "GeoTrackingRestApiGeofencingServiceC5DE9446",
+            "LambdaFunctionsStackDriverLocationCleanupLambda1F1F880E",
+            "LambdaFunctionsStackDriverLocationUpdateIngestLambda504D6AD3",
+            "LambdaFunctionsStackDriverGeofencingLambda40A7BA6E",
+            "LambdaFunctionsStackDriverStatusUpdateLambda84DE0655",
+            "LambdaFunctionsStackESInitialSetupLambdaB25C3E0D",
+            "ApiGeoTrackingGetDemAreaSettingsLambda6C4A12E4"
           ],
           "line_numbers": [
-            90,
-            6108,
-            6398,
-            6540,
-            6730,
-            6919,
-            7254,
-            7565,
-            7936,
-            8144,
-            8343,
-            8597,
-            8931,
-            9245,
-            9575,
-            9746,
-            9928,
-            10069,
-            10386,
-            10614,
-            10784
+            2748,
+            2929,
+            3157,
+            3354,
+            3809,
+            4104,
+            4407,
+            4681,
+            4859,
+            5063
           ],
           "element_types": [
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource"
-          ]
-        },
-        {
-          "id": "W89",
-          "name": "LambdaFunctionInsideVPCRule",
-          "type": "WARN",
-          "message": "Lambda functions should be deployed inside a VPC",
-          "logical_resource_ids": [
-            "AWS679f53fac002430cb0da5b7982bd22872D164C4C",
-            "SimulatorManagerSimulatorManagerLambdaESCSStepFunctionInvokerECSTaskRunHelperF98A49C7",
-            "SimulatorManagerSimulatorManagerLambda269D5609",
-            "SimulatorManagerEventsSimulatorEventSimulatorLambda192B31F9",
-            "SimulatorManagerPolygonManagerLambdaB5FAE450",
-            "SimulatorManagerOriginSimulatorLambdaOriginGeneratorStepFunctionOriginGeneratorHelperC2BD95BD",
-            "SimulatorManagerOriginSimulatorLambdaOriginStarterStepFunctionOriginStarterHelperA28A5905",
-            "SimulatorManagerOriginSimulatorLambdaOriginEraserStepFunctionOriginEraserHelperFE478FE3",
-            "SimulatorManagerOriginSimulatorLambdaOriginEventHandler70EF4889",
-            "SimulatorManagerDestinationSimulatorLambdaDestinationGeneratorStepFunctionDestinationGeneratorHelperD80AFFC5",
-            "SimulatorManagerDestinationSimulatorLambdaDestinationStarterStepFunctionDestinationStarterHelper6D16BE0E",
-            "SimulatorManagerDestinationSimulatorLambdaDestinationEraserStepFunctionDestinationEraserHelperEEF2F7D1",
-            "SimulatorManagerDestinationSimulatorLambdaE614D361",
-            "SimulatorManagerDestinationSimulatorLambdaS3PresignedUrlLambdaE6ECBCFE",
-            "SimulatorManagerOrderSimulatorLambda1D914205",
-            "SimulatorManagerInstantDeliveryDispatcherAssignmentQueryLambda7796E184",
-            "SimulatorManagerSameDayDeliveryDispatcherAssignmentQueryLambda00538C73"
-          ],
-          "line_numbers": [
-            90,
-            6108,
-            6398,
-            6540,
-            6730,
-            6919,
-            7254,
-            7565,
-            8343,
-            8597,
-            8931,
-            9245,
-            9575,
-            9928,
-            10069,
-            10614,
-            10784
-          ],
-          "element_types": [
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
             "resource",
             "resource",
             "resource",
@@ -454,63 +636,30 @@
           "type": "WARN",
           "message": "Lambda functions should define ReservedConcurrentExecutions to reserve simultaneous executions",
           "logical_resource_ids": [
-            "AWS679f53fac002430cb0da5b7982bd22872D164C4C",
-            "SimulatorManagerSimulatorManagerLambdaESCSStepFunctionInvokerECSTaskRunHelperF98A49C7",
-            "SimulatorManagerSimulatorManagerLambda269D5609",
-            "SimulatorManagerEventsSimulatorEventSimulatorLambda192B31F9",
-            "SimulatorManagerPolygonManagerLambdaB5FAE450",
-            "SimulatorManagerOriginSimulatorLambdaOriginGeneratorStepFunctionOriginGeneratorHelperC2BD95BD",
-            "SimulatorManagerOriginSimulatorLambdaOriginStarterStepFunctionOriginStarterHelperA28A5905",
-            "SimulatorManagerOriginSimulatorLambdaOriginEraserStepFunctionOriginEraserHelperFE478FE3",
-            "SimulatorManagerOriginSimulatorLambda669B2FA5",
-            "SimulatorManagerOriginSimulatorLambdaOriginStatusUpdateLambdaD5130653",
-            "SimulatorManagerOriginSimulatorLambdaOriginEventHandler70EF4889",
-            "SimulatorManagerDestinationSimulatorLambdaDestinationGeneratorStepFunctionDestinationGeneratorHelperD80AFFC5",
-            "SimulatorManagerDestinationSimulatorLambdaDestinationStarterStepFunctionDestinationStarterHelper6D16BE0E",
-            "SimulatorManagerDestinationSimulatorLambdaDestinationEraserStepFunctionDestinationEraserHelperEEF2F7D1",
-            "SimulatorManagerDestinationSimulatorLambdaE614D361",
-            "SimulatorManagerDestinationSimulatorLambdaDestinationStatusUpdateLambda7FD0C441",
-            "SimulatorManagerDestinationSimulatorLambdaS3PresignedUrlLambdaE6ECBCFE",
-            "SimulatorManagerOrderSimulatorLambda1D914205",
-            "SimulatorManagerStatsSimulatorLambdaStatisticsLambdaD6482994",
-            "SimulatorManagerInstantDeliveryDispatcherAssignmentQueryLambda7796E184",
-            "SimulatorManagerSameDayDeliveryDispatcherAssignmentQueryLambda00538C73"
+            "GeoTrackingRestApiGetDriverLocationLambda16797A58",
+            "GeoTrackingRestApiQueryDriversLambdaDC17E2A5",
+            "GeoTrackingRestApiListDriversForPolygonLambda2F311273",
+            "GeoTrackingRestApiGeofencingServiceC5DE9446",
+            "LambdaFunctionsStackDriverLocationCleanupLambda1F1F880E",
+            "LambdaFunctionsStackDriverLocationUpdateIngestLambda504D6AD3",
+            "LambdaFunctionsStackDriverGeofencingLambda40A7BA6E",
+            "LambdaFunctionsStackDriverStatusUpdateLambda84DE0655",
+            "LambdaFunctionsStackESInitialSetupLambdaB25C3E0D",
+            "ApiGeoTrackingGetDemAreaSettingsLambda6C4A12E4"
           ],
           "line_numbers": [
-            90,
-            6108,
-            6398,
-            6540,
-            6730,
-            6919,
-            7254,
-            7565,
-            7936,
-            8144,
-            8343,
-            8597,
-            8931,
-            9245,
-            9575,
-            9746,
-            9928,
-            10069,
-            10386,
-            10614,
-            10784
+            2748,
+            2929,
+            3157,
+            3354,
+            3809,
+            4104,
+            4407,
+            4681,
+            4859,
+            5063
           ],
           "element_types": [
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
             "resource",
             "resource",
             "resource",
@@ -524,31 +673,34 @@
           ]
         },
         {
-          "id": "W76",
-          "name": "SPCMRule",
+          "id": "W28",
+          "name": "ResourceWithExplicitNameRule",
           "type": "WARN",
-          "message": "SPCM for IAM policy document is higher than 25",
+          "message": "Resource found with an explicit name, this disallows updates that require replacement of this resource",
           "logical_resource_ids": [
-            "SimulatorManagerOriginSimulatorLambdaOriginGeneratorStepFunctionOriginGeneratorHelperServiceRoleDefaultPolicy7F7C5518",
-            "SimulatorManagerOriginSimulatorLambdaOriginStarterStepFunctionOriginStarterHelperServiceRoleDefaultPolicyCBE0EF66",
-            "SimulatorManagerOriginSimulatorLambdaServiceRoleDefaultPolicyB9182468",
-            "SimulatorManagerDestinationSimulatorLambdaDestinationGeneratorStepFunctionDestinationGeneratorHelperServiceRoleDefaultPolicy26A5D211",
-            "SimulatorManagerDestinationSimulatorLambdaDestinationStarterStepFunctionDestinationStarterHelperServiceRoleDefaultPolicy4FA4D8AD",
-            "SimulatorManagerDestinationSimulatorLambdaServiceRoleDefaultPolicyEC8238D5"
+            "GeoTrackingRestApidevprotoApiKeyGeoTrackingApiZ14orxO5BD65768"
           ],
           "line_numbers": [
-            6817,
-            7166,
-            7801,
-            8495,
-            8843,
-            9469
+            2582
           ],
           "element_types": [
-            "resource",
-            "resource",
-            "resource",
-            "resource",
+            "resource"
+          ]
+        },
+        {
+          "id": "W48",
+          "name": "SqsQueueKmsMasterKeyIdRule",
+          "type": "WARN",
+          "message": "SQS Queue should specify KmsMasterKeyId property",
+          "logical_resource_ids": [
+            "LambdaFunctionsStackKinesisIngestConsumerdriverIngestDlqB65AFC33",
+            "LambdaFunctionsStackKinesisGeofencingConsumergeofencingDlq731D69E3"
+          ],
+          "line_numbers": [
+            4190,
+            4493
+          ],
+          "element_types": [
             "resource",
             "resource"
           ]
@@ -557,7 +709,7 @@
     }
   },
   {
-    "filename": "./cdk.out.dev/Dev-Backend.template.json",
+    "filename": "./cdk.out.dev/DevBackendOrderOrchestrationStack113F9242.nested.template.json",
     "file_results": {
       "failure_count": 0,
       "violations": [
@@ -567,214 +719,16 @@
           "type": "WARN",
           "message": "IAM policy should not allow * resource",
           "logical_resource_ids": [
-            "IoTEndpointBackendStackCustomResourcePolicy80EB5EED"
+            "OrderManagerStackOrderManagerHelperServiceRoleDefaultPolicy272FF686",
+            "OrderManagerStackProviderRuleEngineServiceRoleDefaultPolicy3804ECF8",
+            "OrderManagerStackOrderManagerHandlerServiceRoleDefaultPolicy8E9977C4"
           ],
           "line_numbers": [
-            5
+            56,
+            246,
+            727
           ],
           "element_types": [
-            "resource"
-          ]
-        },
-        {
-          "id": "W58",
-          "name": "LambdaFunctionCloudWatchLogsRule",
-          "type": "WARN",
-          "message": "Lambda functions require permission to write CloudWatch Logs",
-          "logical_resource_ids": [
-            "AWS679f53fac002430cb0da5b7982bd22872D164C4C"
-          ],
-          "line_numbers": [
-            90
-          ],
-          "element_types": [
-            "resource"
-          ]
-        },
-        {
-          "id": "W89",
-          "name": "LambdaFunctionInsideVPCRule",
-          "type": "WARN",
-          "message": "Lambda functions should be deployed inside a VPC",
-          "logical_resource_ids": [
-            "AWS679f53fac002430cb0da5b7982bd22872D164C4C"
-          ],
-          "line_numbers": [
-            90
-          ],
-          "element_types": [
-            "resource"
-          ]
-        },
-        {
-          "id": "W92",
-          "name": "LambdaFunctionReservedConcurrentExecutionsRule",
-          "type": "WARN",
-          "message": "Lambda functions should define ReservedConcurrentExecutions to reserve simultaneous executions",
-          "logical_resource_ids": [
-            "AWS679f53fac002430cb0da5b7982bd22872D164C4C"
-          ],
-          "line_numbers": [
-            90
-          ],
-          "element_types": [
-            "resource"
-          ]
-        }
-      ]
-    }
-  },
-  {
-    "filename": "./cdk.out.dev/ExternalProviderStackMockExternalPollingProviderStackExternalPollingDataB5D68882.nested.template.json",
-    "file_results": {
-      "failure_count": 0,
-      "violations": [
-        {
-          "id": "W78",
-          "name": "DynamoDBBackupRule",
-          "type": "WARN",
-          "message": "DynamoDB table should have backup enabled, should be set using PointInTimeRecoveryEnabled",
-          "logical_resource_ids": [
-            "ExamplePollingOrdersF4C35FA1"
-          ],
-          "line_numbers": [
-            4
-          ],
-          "element_types": [
-            "resource"
-          ]
-        },
-        {
-          "id": "W28",
-          "name": "ResourceWithExplicitNameRule",
-          "type": "WARN",
-          "message": "Resource found with an explicit name, this disallows updates that require replacement of this resource",
-          "logical_resource_ids": [
-            "ExamplePollingOrdersF4C35FA1"
-          ],
-          "line_numbers": [
-            4
-          ],
-          "element_types": [
-            "resource"
-          ]
-        }
-      ]
-    }
-  },
-  {
-    "filename": "./cdk.out.dev/DevPersistentBackendInternalIdentityStackPersistent8522B336.nested.template.json",
-    "file_results": {
-      "failure_count": 0,
-      "violations": [
-        {
-          "id": "W11",
-          "name": "IamRoleWildcardResourceOnPermissionsPolicyRule",
-          "type": "WARN",
-          "message": "IAM role should not allow * resource on its permissions policy",
-          "logical_resource_ids": [
-            "hyperprotoInternalUserPoolsmsRole5B1A9ACC"
-          ],
-          "line_numbers": [
-            4
-          ],
-          "element_types": [
-            "resource"
-          ]
-        },
-        {
-          "id": "W28",
-          "name": "ResourceWithExplicitNameRule",
-          "type": "WARN",
-          "message": "Resource found with an explicit name, this disallows updates that require replacement of this resource",
-          "logical_resource_ids": [
-            "InternalAuthenticatedRole438E4A1B"
-          ],
-          "line_numbers": [
-            191
-          ],
-          "element_types": [
-            "resource"
-          ]
-        }
-      ]
-    }
-  },
-  {
-    "filename": "./cdk.out.dev/DevPersistentBackendDataStoragePersistent6BE19305.nested.template.json",
-    "file_results": {
-      "failure_count": 0,
-      "violations": [
-        {
-          "id": "W78",
-          "name": "DynamoDBBackupRule",
-          "type": "WARN",
-          "message": "DynamoDB table should have backup enabled, should be set using PointInTimeRecoveryEnabled",
-          "logical_resource_ids": [
-            "GeoPolygonTable42E97153",
-            "OrderTable416EB896",
-            "InstantDeliveryProviderOrdersFBBFF6BF",
-            "DemographicAreaDispatchSettingsB488376F",
-            "DemographicAreaProviderEngineSettingsC557CEE7",
-            "InstantDeliveryProviderLocksC016DD6F",
-            "DispatcherAssignmentsB45A6CFD",
-            "sameDayDeliveryProviderOrdersC715CBA8",
-            "SameDayDeliveryProviderLocks63D22C52",
-            "sameDayDirectPudoDeliveryJobsFABB667E",
-            "SameDayDirectPudoSolverJobs2A9DFB0A",
-            "SameDayDirectPudoHubsD0D7F238",
-            "SameDayDirectPudoVehicleCapacity22ABD79E"
-          ],
-          "line_numbers": [
-            311,
-            344,
-            377,
-            452,
-            500,
-            533,
-            566,
-            622,
-            725,
-            758,
-            847,
-            895,
-            943
-          ],
-          "element_types": [
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource"
-          ]
-        },
-        {
-          "id": "W12",
-          "name": "IamPolicyWildcardResourceRule",
-          "type": "WARN",
-          "message": "IAM policy should not allow * resource",
-          "logical_resource_ids": [
-            "SameDayDirectPudoVehicleCapacitySeederSeedDBSameDayDirectPudoVehicleCapacityCustomResourcePolicy427A1177",
-            "DatabaseSeederSeedDBDemographicAreaProviderEngineSettingsCustomResourcePolicy07D102DC",
-            "DatabaseSeederSeedDBdemographicAreaDispatcherEngineSettingsCustomResourcePolicy4A4DBC5E",
-            "DatabaseSeederSeedDBPolygonTableCoordsCustomResourcePolicy86F9826E"
-          ],
-          "line_numbers": [
-            991,
-            1120,
-            1176,
-            1232
-          ],
-          "element_types": [
-            "resource",
             "resource",
             "resource",
             "resource"
@@ -786,12 +740,18 @@
           "type": "WARN",
           "message": "Lambda functions require permission to write CloudWatch Logs",
           "logical_resource_ids": [
-            "AWS679f53fac002430cb0da5b7982bd22872D164C4C"
+            "OrderManagerStackOrderManagerHelperA1E5F379",
+            "OrderManagerStackProviderRuleEngineACDAE3AD",
+            "OrderManagerStackOrderManagerHandler71247775"
           ],
           "line_numbers": [
-            1087
+            120,
+            342,
+            799
           ],
           "element_types": [
+            "resource",
+            "resource",
             "resource"
           ]
         },
@@ -801,10 +761,10 @@
           "type": "WARN",
           "message": "Lambda functions should be deployed inside a VPC",
           "logical_resource_ids": [
-            "AWS679f53fac002430cb0da5b7982bd22872D164C4C"
+            "OrderManagerStackProviderRuleEngineACDAE3AD"
           ],
           "line_numbers": [
-            1087
+            342
           ],
           "element_types": [
             "resource"
@@ -816,80 +776,17 @@
           "type": "WARN",
           "message": "Lambda functions should define ReservedConcurrentExecutions to reserve simultaneous executions",
           "logical_resource_ids": [
-            "AWS679f53fac002430cb0da5b7982bd22872D164C4C"
+            "OrderManagerStackOrderManagerHelperA1E5F379",
+            "OrderManagerStackProviderRuleEngineACDAE3AD",
+            "OrderManagerStackOrderManagerHandler71247775"
           ],
           "line_numbers": [
-            1087
-          ],
-          "element_types": [
-            "resource"
-          ]
-        },
-        {
-          "id": "W28",
-          "name": "ResourceWithExplicitNameRule",
-          "type": "WARN",
-          "message": "Resource found with an explicit name, this disallows updates that require replacement of this resource",
-          "logical_resource_ids": [
-            "GeoPolygonTable42E97153",
-            "OrderTable416EB896",
-            "InstantDeliveryProviderOrdersFBBFF6BF",
-            "DemographicAreaDispatchSettingsB488376F",
-            "DemographicAreaProviderEngineSettingsC557CEE7",
-            "InstantDeliveryProviderLocksC016DD6F",
-            "DispatcherAssignmentsB45A6CFD",
-            "sameDayDeliveryProviderOrdersC715CBA8",
-            "SameDayDeliveryProviderLocks63D22C52",
-            "sameDayDirectPudoDeliveryJobsFABB667E",
-            "SameDayDirectPudoSolverJobs2A9DFB0A",
-            "SameDayDirectPudoHubsD0D7F238",
-            "SameDayDirectPudoVehicleCapacity22ABD79E"
-          ],
-          "line_numbers": [
-            311,
-            344,
-            377,
-            452,
-            500,
-            533,
-            566,
-            622,
-            725,
-            758,
-            847,
-            895,
-            943
+            120,
+            342,
+            799
           ],
           "element_types": [
             "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource"
-          ]
-        },
-        {
-          "id": "W35",
-          "name": "S3BucketAccessLoggingRule",
-          "type": "WARN",
-          "message": "S3 Bucket should have access logging configured",
-          "logical_resource_ids": [
-            "DispatchEngineBucketE3BFC9C5",
-            "DriversTelemetryBucket0AE0FD9C"
-          ],
-          "line_numbers": [
-            4,
-            229
-          ],
-          "element_types": [
             "resource",
             "resource"
           ]
@@ -925,21 +822,21 @@
             "SameDayDeliveryProviderProviderApiGwInstanceSameDayDeliveryProvidercallbackPOST8EF60B35"
           ],
           "line_numbers": [
-            1057,
-            1282,
-            1507,
-            3201,
-            3426,
-            3651,
-            3819,
-            5402,
-            5627,
-            5852,
-            6020,
-            7323,
-            7548,
-            7773,
-            7941
+            1100,
+            1325,
+            1550,
+            3252,
+            3477,
+            3702,
+            3870,
+            5461,
+            5686,
+            5911,
+            6079,
+            7382,
+            7607,
+            7832,
+            8000
           ],
           "element_types": [
             "resource",
@@ -971,10 +868,10 @@
             "SameDayDeliveryProviderProviderApiGwInstanceSameDayDeliveryProviderDeploymentStageprodADC25D76"
           ],
           "line_numbers": [
-            860,
-            3004,
-            5205,
-            7126
+            903,
+            3055,
+            5264,
+            7185
           ],
           "element_types": [
             "resource",
@@ -992,7 +889,7 @@
             "GraphhopperSetupGraphhopperALB4E50D909"
           ],
           "line_numbers": [
-            8425
+            8484
           ],
           "element_types": [
             "resource"
@@ -1007,7 +904,7 @@
             "GraphhopperSetupGraphhopperALBGHListenerB51A0073"
           ],
           "line_numbers": [
-            8464
+            8523
           ],
           "element_types": [
             "resource"
@@ -1027,7 +924,7 @@
             "ExampleWebhookProviderRequestOrderFulfillmentLambdaServiceRoleDefaultPolicy5234EEC9",
             "ExampleWebhookProviderGetOrderStatusLambdaServiceRoleDefaultPolicyE5BADB9D",
             "ExampleWebhookProviderCancelOrderLambdaServiceRoleDefaultPolicy5FD707BE",
-            "ExampleWebhookProviderWebhookProviderLambdaConfigurationResourcel2ss874nCustomResourcePolicy0A6BA4C4",
+            "ExampleWebhookProviderWebhookProviderLambdaConfigurationResourcela9apxpzCustomResourcePolicyAA3ADE33",
             "InstantDeliveryProviderInternalCallbackLambdaServiceRoleDefaultPolicy5703DF3B",
             "InstantDeliveryProviderRequestOrderFulfillmentLambdaServiceRoleDefaultPolicy1E302C8A",
             "InstantDeliveryProviderGetOrderStatusLambdaServiceRoleDefaultPolicyB83AB6F6",
@@ -1047,32 +944,32 @@
             "SameDayDriverEventHandlerDriverCleanupLambdaServiceRoleDefaultPolicy1EFB4CDB"
           ],
           "line_numbers": [
-            56,
-            282,
-            555,
-            1786,
-            2060,
-            2270,
-            2496,
-            2722,
-            4046,
-            4365,
-            4548,
-            4758,
-            4952,
-            6299,
-            6482,
-            6679,
-            6873,
-            8305,
-            8669,
-            9188,
-            9423,
-            9622,
-            10150,
-            10504,
-            10822,
-            11038
+            93,
+            321,
+            596,
+            1829,
+            2105,
+            2315,
+            2543,
+            2771,
+            4097,
+            4424,
+            4607,
+            4817,
+            5011,
+            6358,
+            6541,
+            6738,
+            6932,
+            8364,
+            8728,
+            9279,
+            9514,
+            9713,
+            10273,
+            10643,
+            10961,
+            11177
           ],
           "element_types": [
             "resource",
@@ -1112,7 +1009,7 @@
             "DriverDataIngestStreamIdB09121CE"
           ],
           "line_numbers": [
-            4281
+            4340
           ],
           "element_types": [
             "resource"
@@ -1153,33 +1050,33 @@
             "SameDayDriverEventHandlerSubMinuteExecutionStepFunctionSameDayDeliverySubMinuteExecutionHelperB92E2BC8"
           ],
           "line_numbers": [
-            124,
-            350,
-            646,
-            1880,
-            2114,
-            2338,
-            2564,
-            2790,
-            4248,
-            4404,
-            4607,
-            4804,
-            5001,
-            6338,
-            6531,
-            6725,
-            6922,
-            8763,
-            9287,
-            9506,
-            9702,
-            9852,
-            10249,
-            10592,
-            10919,
-            11108,
-            11255
+            161,
+            389,
+            687,
+            1923,
+            2159,
+            2383,
+            2611,
+            2839,
+            4307,
+            4463,
+            4666,
+            4863,
+            5060,
+            6397,
+            6590,
+            6784,
+            6981,
+            8822,
+            9378,
+            9597,
+            9793,
+            9943,
+            10372,
+            10731,
+            11058,
+            11247,
+            11394
           ],
           "element_types": [
             "resource",
@@ -1228,15 +1125,15 @@
             "SameDayDriverEventHandlerSubMinuteExecutionStepFunctionSameDayDeliverySubMinuteExecutionHelperB92E2BC8"
           ],
           "line_numbers": [
-            4248,
-            9287,
-            9506,
-            9702,
-            9852,
-            10592,
-            10919,
-            11108,
-            11255
+            4307,
+            9378,
+            9597,
+            9793,
+            9943,
+            10731,
+            11058,
+            11247,
+            11394
           ],
           "element_types": [
             "resource",
@@ -1285,33 +1182,33 @@
             "SameDayDriverEventHandlerSubMinuteExecutionStepFunctionSameDayDeliverySubMinuteExecutionHelperB92E2BC8"
           ],
           "line_numbers": [
-            124,
-            350,
-            646,
-            1880,
-            2114,
-            2338,
-            2564,
-            2790,
-            4248,
-            4404,
-            4607,
-            4804,
-            5001,
-            6338,
-            6531,
-            6725,
-            6922,
-            8763,
-            9287,
-            9506,
-            9702,
-            9852,
-            10249,
-            10592,
-            10919,
-            11108,
-            11255
+            161,
+            389,
+            687,
+            1923,
+            2159,
+            2383,
+            2611,
+            2839,
+            4307,
+            4463,
+            4666,
+            4863,
+            5060,
+            6397,
+            6590,
+            6784,
+            6981,
+            8822,
+            9378,
+            9597,
+            9793,
+            9943,
+            10372,
+            10731,
+            11058,
+            11247,
+            11394
           ],
           "element_types": [
             "resource",
@@ -1352,7 +1249,7 @@
             "GraphhopperSetupGraphhopperTaskDefgraphhopperindonesiaLogGroup5BC3A5AC"
           ],
           "line_numbers": [
-            8263
+            8322
           ],
           "element_types": [
             "resource"
@@ -1367,7 +1264,7 @@
             "GraphhopperSetupGraphhopperTaskDefgraphhopperindonesiaLogGroup5BC3A5AC"
           ],
           "line_numbers": [
-            8263
+            8322
           ],
           "element_types": [
             "resource"
@@ -1387,12 +1284,12 @@
             "DriverDataIngestStreamIdB09121CE"
           ],
           "line_numbers": [
-            1547,
-            3859,
-            6060,
-            7981,
-            8425,
-            4281
+            1590,
+            3910,
+            6119,
+            8040,
+            8484,
+            4340
           ],
           "element_types": [
             "resource",
@@ -1413,8 +1310,8 @@
             "SameDayDriverEventHandlerDriverStatusChangeHandlerServiceRoleDefaultPolicy585AC411"
           ],
           "line_numbers": [
-            10150,
-            10822
+            10273,
+            10961
           ],
           "element_types": [
             "resource",
@@ -1433,10 +1330,10 @@
             "SameDayDeliveryDispatchEngineOrchestratorSameDayDeliveryBatchIgestionIntervalDeadLetter6A5F9D4B"
           ],
           "line_numbers": [
-            456,
-            474,
-            9366,
-            10667
+            497,
+            515,
+            9457,
+            10806
           ],
           "element_types": [
             "resource",
@@ -1449,11 +1346,126 @@
     }
   },
   {
-    "filename": "./cdk.out.dev/Dev-DebugStack.template.json",
+    "filename": "./cdk.out.dev/DevBackendStreamingNestedStackDF55A304.nested.template.json",
     "file_results": {
       "failure_count": 0,
       "violations": [
-
+        {
+          "id": "W49",
+          "name": "KinesisStreamStreamEncryptionRule",
+          "type": "WARN",
+          "message": "Kinesis Stream should specify StreamEncryption. EncryptionType should be KMS and specify KMS Key Id.",
+          "logical_resource_ids": [
+            "DriverDataStreamDriverDataIngestStreamId27485230"
+          ],
+          "line_numbers": [
+            4
+          ],
+          "element_types": [
+            "resource"
+          ]
+        },
+        {
+          "id": "W28",
+          "name": "ResourceWithExplicitNameRule",
+          "type": "WARN",
+          "message": "Resource found with an explicit name, this disallows updates that require replacement of this resource",
+          "logical_resource_ids": [
+            "DriverFirehoseDriverFirehoseRole726B5A11",
+            "DriverDataStreamDriverDataIngestStreamId27485230"
+          ],
+          "line_numbers": [
+            36,
+            4
+          ],
+          "element_types": [
+            "resource",
+            "resource"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "filename": "./cdk.out.dev/DevDebugStackMonitoringNestedStackB8C8B473.nested.template.json",
+    "file_results": {
+      "failure_count": 0,
+      "violations": [
+        {
+          "id": "W58",
+          "name": "LambdaFunctionCloudWatchLogsRule",
+          "type": "WARN",
+          "message": "Lambda functions require permission to write CloudWatch Logs",
+          "logical_resource_ids": [
+            "AWS679f53fac002430cb0da5b7982bd22872D164C4C"
+          ],
+          "line_numbers": [
+            485
+          ],
+          "element_types": [
+            "resource"
+          ]
+        },
+        {
+          "id": "W89",
+          "name": "LambdaFunctionInsideVPCRule",
+          "type": "WARN",
+          "message": "Lambda functions should be deployed inside a VPC",
+          "logical_resource_ids": [
+            "AWS679f53fac002430cb0da5b7982bd22872D164C4C"
+          ],
+          "line_numbers": [
+            485
+          ],
+          "element_types": [
+            "resource"
+          ]
+        },
+        {
+          "id": "W92",
+          "name": "LambdaFunctionReservedConcurrentExecutionsRule",
+          "type": "WARN",
+          "message": "Lambda functions should define ReservedConcurrentExecutions to reserve simultaneous executions",
+          "logical_resource_ids": [
+            "AWS679f53fac002430cb0da5b7982bd22872D164C4C"
+          ],
+          "line_numbers": [
+            485
+          ],
+          "element_types": [
+            "resource"
+          ]
+        },
+        {
+          "id": "W28",
+          "name": "ResourceWithExplicitNameRule",
+          "type": "WARN",
+          "message": "Resource found with an explicit name, this disallows updates that require replacement of this resource",
+          "logical_resource_ids": [
+            "MonitoringInstDebugInstanceRole907F1010"
+          ],
+          "line_numbers": [
+            288
+          ],
+          "element_types": [
+            "resource"
+          ]
+        },
+        {
+          "id": "W35",
+          "name": "S3BucketAccessLoggingRule",
+          "type": "WARN",
+          "message": "S3 Bucket should have access logging configured",
+          "logical_resource_ids": [
+            "MonitoringInstDebugInstanceBucket375E51C4"
+          ],
+          "line_numbers": [
+            4
+          ],
+          "element_types": [
+            "resource"
+          ]
+        }
       ]
     }
   },
@@ -1486,7 +1498,7 @@
             "AWS679f53fac002430cb0da5b7982bd22872D164C4C"
           ],
           "line_numbers": [
-            849
+            879
           ],
           "element_types": [
             "resource"
@@ -1501,7 +1513,7 @@
             "AWS679f53fac002430cb0da5b7982bd22872D164C4C"
           ],
           "line_numbers": [
-            849
+            879
           ],
           "element_types": [
             "resource"
@@ -1516,7 +1528,7 @@
             "AWS679f53fac002430cb0da5b7982bd22872D164C4C"
           ],
           "line_numbers": [
-            849
+            879
           ],
           "element_types": [
             "resource"
@@ -1555,7 +1567,7 @@
             "LiveDataCacheMemoryDBClusterMemoryDBClusterPasswordCD06424D"
           ],
           "line_numbers": [
-            697
+            692
           ],
           "element_types": [
             "resource"
@@ -1649,10 +1661,85 @@
     }
   },
   {
-    "filename": "./cdk.out.dev/DevDebugStackMonitoringNestedStackB8C8B473.nested.template.json",
+    "filename": "./cdk.out.dev/DevPersistentBackendDataStoragePersistent6BE19305.nested.template.json",
     "file_results": {
       "failure_count": 0,
       "violations": [
+        {
+          "id": "W78",
+          "name": "DynamoDBBackupRule",
+          "type": "WARN",
+          "message": "DynamoDB table should have backup enabled, should be set using PointInTimeRecoveryEnabled",
+          "logical_resource_ids": [
+            "RootDataStorageOrderTableE2CF8293",
+            "RootDataStorageDemographicAreaProviderEngineSettings5BE04983",
+            "LocationServiceDataStorageGeoPolygonTable04810E19",
+            "InstantDeliveryDataStorageDispatcherAssignments8C26B97E",
+            "InstantDeliveryDataStorageInstantDeliveryProviderOrdersC633C303",
+            "InstantDeliveryDataStorageInstantDeliveryProviderLocks0E8743CB",
+            "InstantDeliveryDataStorageDemographicAreaDispatchSettings1E2A22C4",
+            "SameDayDeliveryDataStoragesameDayDeliveryProviderOrders95B90284",
+            "SameDayDeliveryDataStorageSameDayDeliveryProviderLocks8B6E0919",
+            "SameDayDeliveryDataStoragesameDayDirectPudoDeliveryJobsBD14001D",
+            "SameDayDeliveryDataStorageSameDayDirectPudoSolverJobsC360DCD1",
+            "SameDayDeliveryDataStorageSameDayDirectPudoHubsC3019059",
+            "SameDayDeliveryDataStorageSameDayDirectPudoVehicleCapacity0FA6B6EA"
+          ],
+          "line_numbers": [
+            4,
+            37,
+            208,
+            522,
+            578,
+            653,
+            686,
+            790,
+            893,
+            926,
+            1015,
+            1063,
+            1111
+          ],
+          "element_types": [
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource"
+          ]
+        },
+        {
+          "id": "W12",
+          "name": "IamPolicyWildcardResourceRule",
+          "type": "WARN",
+          "message": "IAM policy should not allow * resource",
+          "logical_resource_ids": [
+            "RootDataStorageRootDataStorageDemographicAreaProviderEnginerSeederRootDataStorageDemographicAreaProviderEngineSettingsCustomResourcePolicy6146847C",
+            "LocationServiceDataStorageLocationServicePolygonDbCoordsSeederSeedDBPolygonTableCoordsCustomResourcePolicy2F75BABC",
+            "InstantDeliveryDataStorageInstantDeliveryDemographicAreaDispatcherEngineSeederSeedDBdemographicAreaDispatcherEngineSettingsCustomResourcePolicy9552DC6C",
+            "SameDayDeliveryDataStorageSameDayDirectPudoVehicleCapacitySeederSeedDBSameDayDirectPudoVehicleCapacityCustomResourcePolicyA2B9B54E"
+          ],
+          "line_numbers": [
+            70,
+            241,
+            734,
+            1159
+          ],
+          "element_types": [
+            "resource",
+            "resource",
+            "resource",
+            "resource"
+          ]
+        },
         {
           "id": "W58",
           "name": "LambdaFunctionCloudWatchLogsRule",
@@ -1662,7 +1749,7 @@
             "AWS679f53fac002430cb0da5b7982bd22872D164C4C"
           ],
           "line_numbers": [
-            485
+            1255
           ],
           "element_types": [
             "resource"
@@ -1677,7 +1764,7 @@
             "AWS679f53fac002430cb0da5b7982bd22872D164C4C"
           ],
           "line_numbers": [
-            485
+            1255
           ],
           "element_types": [
             "resource"
@@ -1692,7 +1779,7 @@
             "AWS679f53fac002430cb0da5b7982bd22872D164C4C"
           ],
           "line_numbers": [
-            485
+            1255
           ],
           "element_types": [
             "resource"
@@ -1704,12 +1791,48 @@
           "type": "WARN",
           "message": "Resource found with an explicit name, this disallows updates that require replacement of this resource",
           "logical_resource_ids": [
-            "MonitoringInstDebugInstanceRole907F1010"
+            "RootDataStorageOrderTableE2CF8293",
+            "RootDataStorageDemographicAreaProviderEngineSettings5BE04983",
+            "LocationServiceDataStorageGeoPolygonTable04810E19",
+            "InstantDeliveryDataStorageDispatcherAssignments8C26B97E",
+            "InstantDeliveryDataStorageInstantDeliveryProviderOrdersC633C303",
+            "InstantDeliveryDataStorageInstantDeliveryProviderLocks0E8743CB",
+            "InstantDeliveryDataStorageDemographicAreaDispatchSettings1E2A22C4",
+            "SameDayDeliveryDataStoragesameDayDeliveryProviderOrders95B90284",
+            "SameDayDeliveryDataStorageSameDayDeliveryProviderLocks8B6E0919",
+            "SameDayDeliveryDataStoragesameDayDirectPudoDeliveryJobsBD14001D",
+            "SameDayDeliveryDataStorageSameDayDirectPudoSolverJobsC360DCD1",
+            "SameDayDeliveryDataStorageSameDayDirectPudoHubsC3019059",
+            "SameDayDeliveryDataStorageSameDayDirectPudoVehicleCapacity0FA6B6EA"
           ],
           "line_numbers": [
-            288
+            4,
+            37,
+            208,
+            522,
+            578,
+            653,
+            686,
+            790,
+            893,
+            926,
+            1015,
+            1063,
+            1111
           ],
           "element_types": [
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
             "resource"
           ]
         },
@@ -1719,12 +1842,15 @@
           "type": "WARN",
           "message": "S3 Bucket should have access logging configured",
           "logical_resource_ids": [
-            "MonitoringInstDebugInstanceBucket375E51C4"
+            "LocationServiceDataStorageDriversTelemetryBucketB80FE0F7",
+            "InstantDeliveryDataStorageDispatchEngineBucket290E4C58"
           ],
           "line_numbers": [
-            4
+            126,
+            297
           ],
           "element_types": [
+            "resource",
             "resource"
           ]
         }
@@ -1732,17 +1858,76 @@
     }
   },
   {
-    "filename": "./cdk.out.dev/DevBackendStreamingNestedStackDF55A304.nested.template.json",
+    "filename": "./cdk.out.dev/DevPersistentBackendIdentityStackPersistentF9E4E218.nested.template.json",
     "file_results": {
       "failure_count": 0,
       "violations": [
         {
-          "id": "W49",
-          "name": "KinesisStreamStreamEncryptionRule",
+          "id": "W57",
+          "name": "CognitoIdentityPoolAllowUnauthenticatedIdentitiesRule",
           "type": "WARN",
-          "message": "Kinesis Stream should specify StreamEncryption. EncryptionType should be KMS and specify KMS Key Id.",
+          "message": "AWS::Cognito::IdentityPool AllowUnauthenticatedIdentities property should be false but CAN be true if proper restrictive IAM roles and permissions are established for unauthenticated users.",
           "logical_resource_ids": [
-            "DriverDataStreamDriverDataIngestStreamId27485230"
+            "devprotoIdentityPool"
+          ],
+          "line_numbers": [
+            266
+          ],
+          "element_types": [
+            "resource"
+          ]
+        },
+        {
+          "id": "W11",
+          "name": "IamRoleWildcardResourceOnPermissionsPolicyRule",
+          "type": "WARN",
+          "message": "IAM role should not allow * resource on its permissions policy",
+          "logical_resource_ids": [
+            "devprotoUserPoolsmsRole3D49E401",
+            "AuthenticatedRole86104F1A"
+          ],
+          "line_numbers": [
+            4,
+            311
+          ],
+          "element_types": [
+            "resource",
+            "resource"
+          ]
+        },
+        {
+          "id": "W28",
+          "name": "ResourceWithExplicitNameRule",
+          "type": "WARN",
+          "message": "Resource found with an explicit name, this disallows updates that require replacement of this resource",
+          "logical_resource_ids": [
+            "AuthenticatedRole86104F1A",
+            "devprotoUnauthenticatedRole29C9E543"
+          ],
+          "line_numbers": [
+            311,
+            380
+          ],
+          "element_types": [
+            "resource",
+            "resource"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "filename": "./cdk.out.dev/DevPersistentBackendInternalIdentityStackPersistent8522B336.nested.template.json",
+    "file_results": {
+      "failure_count": 0,
+      "violations": [
+        {
+          "id": "W11",
+          "name": "IamRoleWildcardResourceOnPermissionsPolicyRule",
+          "type": "WARN",
+          "message": "IAM role should not allow * resource on its permissions policy",
+          "logical_resource_ids": [
+            "devprotoInternalUserPoolsmsRole32FADC23"
           ],
           "line_numbers": [
             4
@@ -1757,15 +1942,12 @@
           "type": "WARN",
           "message": "Resource found with an explicit name, this disallows updates that require replacement of this resource",
           "logical_resource_ids": [
-            "DriverFirehoseDriverFirehoseRole726B5A11",
-            "DriverDataStreamDriverDataIngestStreamId27485230"
+            "InternalAuthenticatedRole438E4A1B"
           ],
           "line_numbers": [
-            36,
-            4
+            191
           ],
           "element_types": [
-            "resource",
             "resource"
           ]
         }
@@ -1783,20 +1965,20 @@
           "type": "WARN",
           "message": "AWS::ApiGateway::Method should not have AuthorizationType set to 'NONE' unless it is of HttpMethod: OPTIONS.",
           "logical_resource_ids": [
-            "ExternalPollingProviderStackExternalPollingProviderApiorderPOSTE389D39B",
-            "ExternalPollingProviderStackExternalPollingProviderApiorderorderIdGET2FCDAFF8",
-            "ExternalPollingProviderStackExternalPollingProviderApiorderorderIdDELETEA8A385D4",
-            "ExternalWebhookProviderStackExternalWebhookProviderApiorderPOST0D88F875",
-            "ExternalWebhookProviderStackExternalWebhookProviderApiorderorderIdGETCB428F34",
-            "ExternalWebhookProviderStackExternalWebhookProviderApiorderorderIdDELETE0D496FC3"
+            "ExternalPollingMockPollingProviderExternalPollingProviderApiorderPOSTC4258E1F",
+            "ExternalPollingMockPollingProviderExternalPollingProviderApiorderorderIdGET83EE5142",
+            "ExternalPollingMockPollingProviderExternalPollingProviderApiorderorderIdDELETED5A87C9C",
+            "ExternalWebhookMockWebhookProviderExternalWebhookProviderApiorderPOST73FBDBCB",
+            "ExternalWebhookMockWebhookProviderExternalWebhookProviderApiorderorderIdGET10216F9F",
+            "ExternalWebhookMockWebhookProviderExternalWebhookProviderApiorderorderIdDELETE03C9FC31"
           ],
           "line_numbers": [
             454,
             619,
             727,
-            1613,
-            1778,
-            1886
+            1646,
+            1811,
+            1919
           ],
           "element_types": [
             "resource",
@@ -1813,12 +1995,12 @@
           "type": "WARN",
           "message": "AWS::ApiGateway::Stage should have the AccessLogSetting property defined.",
           "logical_resource_ids": [
-            "ExternalPollingProviderStackExternalPollingProviderApiDeploymentStageprod1FB12453",
-            "ExternalWebhookProviderStackExternalWebhookProviderApiDeploymentStageprod1D68BB84"
+            "ExternalPollingMockPollingProviderExternalPollingProviderApiDeploymentStageprod387F33BB",
+            "ExternalWebhookMockWebhookProviderExternalWebhookProviderApiDeploymentStageprod52E41C24"
           ],
           "line_numbers": [
             257,
-            1416
+            1449
           ],
           "element_types": [
             "resource",
@@ -1834,7 +2016,7 @@
             "ExternalProviderSetupServiceRoleDefaultPolicy8D6BF04A"
           ],
           "line_numbers": [
-            2153
+            2219
           ],
           "element_types": [
             "resource"
@@ -1846,18 +2028,18 @@
           "type": "WARN",
           "message": "Lambda functions require permission to write CloudWatch Logs",
           "logical_resource_ids": [
-            "ExternalPollingProviderStackExternalPollingServiceLambdaCCBAA714",
-            "ExternalWebhookProviderStackExternalWebhookServiceLambda2D80F960",
-            "ExternalWebhookProviderStackExternalWebhookInvokerStackExternalWebhookInvokerC5553C91",
+            "ExternalPollingMockPollingProviderExternalPollingServiceLambda0DF98B83",
+            "ExternalWebhookMockWebhookProviderExternalWebhookServiceLambda1FC32193",
+            "ExternalWebhookMockWebhookProviderExternalWebhookInvokerStackExternalWebhookInvokerC6E79C59",
             "ExternalProviderSetupDB148285",
             "ExternalProviderSetupExternalProviderSetupProviderframeworkonEvent380AEAED"
           ],
           "line_numbers": [
             108,
-            1057,
-            1221,
-            2218,
-            2346
+            1090,
+            1254,
+            2284,
+            2428
           ],
           "element_types": [
             "resource",
@@ -1873,18 +2055,18 @@
           "type": "WARN",
           "message": "Lambda functions should be deployed inside a VPC",
           "logical_resource_ids": [
-            "ExternalPollingProviderStackExternalPollingServiceLambdaCCBAA714",
-            "ExternalWebhookProviderStackExternalWebhookServiceLambda2D80F960",
-            "ExternalWebhookProviderStackExternalWebhookInvokerStackExternalWebhookInvokerC5553C91",
+            "ExternalPollingMockPollingProviderExternalPollingServiceLambda0DF98B83",
+            "ExternalWebhookMockWebhookProviderExternalWebhookServiceLambda1FC32193",
+            "ExternalWebhookMockWebhookProviderExternalWebhookInvokerStackExternalWebhookInvokerC6E79C59",
             "ExternalProviderSetupDB148285",
             "ExternalProviderSetupExternalProviderSetupProviderframeworkonEvent380AEAED"
           ],
           "line_numbers": [
             108,
-            1057,
-            1221,
-            2218,
-            2346
+            1090,
+            1254,
+            2284,
+            2428
           ],
           "element_types": [
             "resource",
@@ -1900,18 +2082,18 @@
           "type": "WARN",
           "message": "Lambda functions should define ReservedConcurrentExecutions to reserve simultaneous executions",
           "logical_resource_ids": [
-            "ExternalPollingProviderStackExternalPollingServiceLambdaCCBAA714",
-            "ExternalWebhookProviderStackExternalWebhookServiceLambda2D80F960",
-            "ExternalWebhookProviderStackExternalWebhookInvokerStackExternalWebhookInvokerC5553C91",
+            "ExternalPollingMockPollingProviderExternalPollingServiceLambda0DF98B83",
+            "ExternalWebhookMockWebhookProviderExternalWebhookServiceLambda1FC32193",
+            "ExternalWebhookMockWebhookProviderExternalWebhookInvokerStackExternalWebhookInvokerC6E79C59",
             "ExternalProviderSetupDB148285",
             "ExternalProviderSetupExternalProviderSetupProviderframeworkonEvent380AEAED"
           ],
           "line_numbers": [
             108,
-            1057,
-            1221,
-            2218,
-            2346
+            1090,
+            1254,
+            2284,
+            2428
           ],
           "element_types": [
             "resource",
@@ -1927,12 +2109,12 @@
           "type": "WARN",
           "message": "Resource found with an explicit name, this disallows updates that require replacement of this resource",
           "logical_resource_ids": [
-            "ExternalPollingProviderStackExternalPollingProviderApiApiKeyExternalPollingZ1pfddS94FD8F36",
-            "ExternalWebhookProviderStackExternalWebhookProviderApiApiKeyExternalWebhook1VO1vMAB9496D7"
+            "ExternalPollingMockPollingProviderExternalPollingProviderApiApiKeyExternalPollingZ18UpIOE38A39C2",
+            "ExternalWebhookMockWebhookProviderExternalWebhookProviderApiApiKeyExternalWebhookZS27ao396A613D"
           ],
           "line_numbers": [
             767,
-            1926
+            1959
           ],
           "element_types": [
             "resource",
@@ -1943,61 +2125,37 @@
     }
   },
   {
-    "filename": "./cdk.out.dev/SimulatorBackendSimulatorWebsiteHosting8EDC668F.nested.template.json",
+    "filename": "./cdk.out.dev/ExternalProviderStackMockExternalPollingMockPollingProviderExternalPollingData8EC96B65.nested.template.json",
     "file_results": {
       "failure_count": 0,
       "violations": [
         {
-          "id": "W58",
-          "name": "LambdaFunctionCloudWatchLogsRule",
+          "id": "W78",
+          "name": "DynamoDBBackupRule",
           "type": "WARN",
-          "message": "Lambda functions require permission to write CloudWatch Logs",
+          "message": "DynamoDB table should have backup enabled, should be set using PointInTimeRecoveryEnabled",
           "logical_resource_ids": [
-            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536",
-            "AWS679f53fac002430cb0da5b7982bd22872D164C4C"
+            "ExamplePollingOrdersF4C35FA1"
           ],
           "line_numbers": [
-            191,
-            457
+            4
           ],
           "element_types": [
-            "resource",
             "resource"
           ]
         },
         {
-          "id": "W89",
-          "name": "LambdaFunctionInsideVPCRule",
+          "id": "W28",
+          "name": "ResourceWithExplicitNameRule",
           "type": "WARN",
-          "message": "Lambda functions should be deployed inside a VPC",
+          "message": "Resource found with an explicit name, this disallows updates that require replacement of this resource",
           "logical_resource_ids": [
-            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536",
-            "AWS679f53fac002430cb0da5b7982bd22872D164C4C"
+            "ExamplePollingOrdersF4C35FA1"
           ],
           "line_numbers": [
-            191,
-            457
+            4
           ],
           "element_types": [
-            "resource",
-            "resource"
-          ]
-        },
-        {
-          "id": "W92",
-          "name": "LambdaFunctionReservedConcurrentExecutionsRule",
-          "type": "WARN",
-          "message": "Lambda functions should define ReservedConcurrentExecutions to reserve simultaneous executions",
-          "logical_resource_ids": [
-            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536",
-            "AWS679f53fac002430cb0da5b7982bd22872D164C4C"
-          ],
-          "line_numbers": [
-            191,
-            457
-          ],
-          "element_types": [
-            "resource",
             "resource"
           ]
         }
@@ -2005,41 +2163,73 @@
     }
   },
   {
-    "filename": "./cdk.out.dev/Dev-PersistentBackend.template.json",
+    "filename": "./cdk.out.dev/ExternalProviderStackMockExternalPollingProviderStackExternalPollingDataB5D68882.nested.template.json",
     "file_results": {
       "failure_count": 0,
       "violations": [
         {
-          "id": "W33",
-          "name": "EC2SubnetMapPublicIpOnLaunchRule",
+          "id": "W78",
+          "name": "DynamoDBBackupRule",
           "type": "WARN",
-          "message": "EC2 Subnet should not have MapPublicIpOnLaunch set to true",
+          "message": "DynamoDB table should have backup enabled, should be set using PointInTimeRecoveryEnabled",
           "logical_resource_ids": [
-            "VpcPersistentVpchyperprotopublicSubnet1SubnetFA85D8C8",
-            "VpcPersistentVpchyperprotopublicSubnet2SubnetE58445CE",
-            "VpcPersistentVpchyperprotopublicSubnet3SubnetD6999EC0"
+            "ExamplePollingOrdersF4C35FA1"
           ],
           "line_numbers": [
-            29,
-            160,
-            245
+            4
           ],
           "element_types": [
-            "resource",
-            "resource",
             "resource"
           ]
         },
         {
-          "id": "W60",
-          "name": "VpcHasFlowLogRule",
+          "id": "W28",
+          "name": "ResourceWithExplicitNameRule",
           "type": "WARN",
-          "message": "VPC should have a flow log attached",
+          "message": "Resource found with an explicit name, this disallows updates that require replacement of this resource",
           "logical_resource_ids": [
-            "VpcPersistentVpc914608BE"
+            "ExamplePollingOrdersF4C35FA1"
           ],
           "line_numbers": [
-            5
+            4
+          ],
+          "element_types": [
+            "resource"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "filename": "./cdk.out.dev/ExternalProviderStackMockExternalWebhookMockWebhookProviderExternalWebhookDataA4F30F33.nested.template.json",
+    "file_results": {
+      "failure_count": 0,
+      "violations": [
+        {
+          "id": "W78",
+          "name": "DynamoDBBackupRule",
+          "type": "WARN",
+          "message": "DynamoDB table should have backup enabled, should be set using PointInTimeRecoveryEnabled",
+          "logical_resource_ids": [
+            "ExampleWebhookOrders90AB4855"
+          ],
+          "line_numbers": [
+            4
+          ],
+          "element_types": [
+            "resource"
+          ]
+        },
+        {
+          "id": "W28",
+          "name": "ResourceWithExplicitNameRule",
+          "type": "WARN",
+          "message": "Resource found with an explicit name, this disallows updates that require replacement of this resource",
+          "logical_resource_ids": [
+            "ExampleWebhookOrders90AB4855"
+          ],
+          "line_numbers": [
+            4
           ],
           "element_types": [
             "resource"
@@ -2087,22 +2277,127 @@
     }
   },
   {
-    "filename": "./cdk.out.dev/DevBackendAppConfigNestedStack0AB9D01F.nested.template.json",
+    "filename": "./cdk.out.dev/Simulator-Backend.template.json",
     "file_results": {
       "failure_count": 0,
       "violations": [
+        {
+          "id": "W68",
+          "name": "ApiGatewayDeploymentUsagePlanRule",
+          "type": "WARN",
+          "message": "AWS::ApiGateway::Deployment resources should be associated with an AWS::ApiGateway::UsagePlan. ",
+          "logical_resource_ids": [
+            "SimulatorRestApiDeployment7165AE7Bc8bfa179c8f078024bdfb65d757d669e"
+          ],
+          "line_numbers": [
+            200
+          ],
+          "element_types": [
+            "resource"
+          ]
+        },
+        {
+          "id": "W69",
+          "name": "ApiGatewayStageAccessLoggingRule",
+          "type": "WARN",
+          "message": "AWS::ApiGateway::Stage should have the AccessLogSetting property defined.",
+          "logical_resource_ids": [
+            "SimulatorRestApiDeploymentStageprod2BCF2C02"
+          ],
+          "line_numbers": [
+            305
+          ],
+          "element_types": [
+            "resource"
+          ]
+        },
+        {
+          "id": "W64",
+          "name": "ApiGatewayStageUsagePlanRule",
+          "type": "WARN",
+          "message": "AWS::ApiGateway::Stage resources should be associated with an AWS::ApiGateway::UsagePlan. ",
+          "logical_resource_ids": [
+            "SimulatorRestApiDeploymentStageprod2BCF2C02"
+          ],
+          "line_numbers": [
+            305
+          ],
+          "element_types": [
+            "resource"
+          ]
+        },
+        {
+          "id": "W52",
+          "name": "ElasticLoadBalancerV2AccessLoggingRule",
+          "type": "WARN",
+          "message": "Elastic Load Balancer V2 should have access logging enabled",
+          "logical_resource_ids": [
+            "MemDBMonitoringMemDBMonitoringALB9CBAD81B"
+          ],
+          "line_numbers": [
+            11553
+          ],
+          "element_types": [
+            "resource"
+          ]
+        },
+        {
+          "id": "W56",
+          "name": "ElasticLoadBalancerV2ListenerProtocolRule",
+          "type": "WARN",
+          "message": "Elastic Load Balancer V2 Listener Protocol should use HTTPS for ALBs",
+          "logical_resource_ids": [
+            "MemDBMonitoringMemDBMonitoringALBMemDBMonitoringListener0E54F5D8"
+          ],
+          "line_numbers": [
+            11592
+          ],
+          "element_types": [
+            "resource"
+          ]
+        },
         {
           "id": "W12",
           "name": "IamPolicyWildcardResourceRule",
           "type": "WARN",
           "message": "IAM policy should not allow * resource",
           "logical_resource_ids": [
-            "DeploymentHandlerLambdaServiceRoleDefaultPolicy5C7DE2FF"
+            "IoTEndpointSimulatorStackCustomResourcePolicyD5FE1C80",
+            "SimulatorManagerSimulatorManagerLambdaServiceRoleDefaultPolicy875CCB78",
+            "SimulatorManagerOriginSimulatorLambdaOriginGeneratorStepFunctionOriginGeneratorHelperServiceRoleDefaultPolicy7F7C5518",
+            "SimulatorManagerOriginSimulatorLambdaServiceRoleDefaultPolicyB9182468",
+            "SimulatorManagerOriginSimulatorLambdaOriginStatusUpdateLambdaServiceRoleDefaultPolicyC378456B",
+            "SimulatorManagerOriginSimulatorLambdaOriginEventHandlerServiceRoleDefaultPolicy70005689",
+            "SimulatorManagerDestinationSimulatorLambdaDestinationGeneratorStepFunctionDestinationGeneratorHelperServiceRoleDefaultPolicy26A5D211",
+            "SimulatorManagerDestinationSimulatorLambdaServiceRoleDefaultPolicyEC8238D5",
+            "SimulatorManagerDestinationSimulatorLambdaDestinationStatusUpdateLambdaServiceRoleDefaultPolicy876D5AC8",
+            "UpdateLambdaConfigurationla9apxwoCustomResourcePolicy269D5677",
+            "MemDBMonitoringMemDBMonitoringTaskDefExecutionRoleDefaultPolicyF7861539"
           ],
           "line_numbers": [
-            301
+            5,
+            6368,
+            6833,
+            7865,
+            8154,
+            8353,
+            8559,
+            9581,
+            9804,
+            11069,
+            11412
           ],
           "element_types": [
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
             "resource"
           ]
         },
@@ -2112,14 +2407,71 @@
           "type": "WARN",
           "message": "Lambda functions require permission to write CloudWatch Logs",
           "logical_resource_ids": [
-            "DeploymentHandlerLambda04B758EE",
-            "AWS679f53fac002430cb0da5b7982bd22872D164C4C"
+            "AWS679f53fac002430cb0da5b7982bd22872D164C4C",
+            "SimulatorManagerSimulatorManagerLambdaESCSStepFunctionInvokerECSTaskRunHelperF98A49C7",
+            "SimulatorManagerSimulatorManagerLambda269D5609",
+            "SimulatorManagerEventsSimulatorEventSimulatorLambda192B31F9",
+            "SimulatorManagerPolygonManagerLambdaB5FAE450",
+            "SimulatorManagerOriginSimulatorLambdaOriginGeneratorStepFunctionOriginGeneratorHelperC2BD95BD",
+            "SimulatorManagerOriginSimulatorLambdaOriginStarterStepFunctionOriginStarterHelperA28A5905",
+            "SimulatorManagerOriginSimulatorLambdaOriginEraserStepFunctionOriginEraserHelperFE478FE3",
+            "SimulatorManagerOriginSimulatorLambda669B2FA5",
+            "SimulatorManagerOriginSimulatorLambdaOriginStatusUpdateLambdaD5130653",
+            "SimulatorManagerOriginSimulatorLambdaOriginEventHandler70EF4889",
+            "SimulatorManagerDestinationSimulatorLambdaDestinationGeneratorStepFunctionDestinationGeneratorHelperD80AFFC5",
+            "SimulatorManagerDestinationSimulatorLambdaDestinationStarterStepFunctionDestinationStarterHelper6D16BE0E",
+            "SimulatorManagerDestinationSimulatorLambdaDestinationEraserStepFunctionDestinationEraserHelperEEF2F7D1",
+            "SimulatorManagerDestinationSimulatorLambdaE614D361",
+            "SimulatorManagerDestinationSimulatorLambdaDestinationStatusUpdateLambda7FD0C441",
+            "SimulatorManagerDestinationSimulatorLambdaS3PresignedUrlLambdaE6ECBCFE",
+            "SimulatorManagerOrderSimulatorLambda1D914205",
+            "SimulatorManagerStatsSimulatorLambdaStatisticsLambdaD6482994",
+            "SimulatorManagerInstantDeliveryDispatcherAssignmentQueryLambda7796E184",
+            "SimulatorManagerSameDayDeliveryDispatcherAssignmentQueryLambda00538C73"
           ],
           "line_numbers": [
-            390,
-            651
+            90,
+            6108,
+            6414,
+            6556,
+            6746,
+            6935,
+            7286,
+            7613,
+            8000,
+            8208,
+            8407,
+            8661,
+            9011,
+            9341,
+            9687,
+            9858,
+            10040,
+            10181,
+            10498,
+            10726,
+            10896
           ],
           "element_types": [
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
             "resource",
             "resource"
           ]
@@ -2130,14 +2482,59 @@
           "type": "WARN",
           "message": "Lambda functions should be deployed inside a VPC",
           "logical_resource_ids": [
-            "DeploymentHandlerLambda04B758EE",
-            "AWS679f53fac002430cb0da5b7982bd22872D164C4C"
+            "AWS679f53fac002430cb0da5b7982bd22872D164C4C",
+            "SimulatorManagerSimulatorManagerLambdaESCSStepFunctionInvokerECSTaskRunHelperF98A49C7",
+            "SimulatorManagerSimulatorManagerLambda269D5609",
+            "SimulatorManagerEventsSimulatorEventSimulatorLambda192B31F9",
+            "SimulatorManagerPolygonManagerLambdaB5FAE450",
+            "SimulatorManagerOriginSimulatorLambdaOriginGeneratorStepFunctionOriginGeneratorHelperC2BD95BD",
+            "SimulatorManagerOriginSimulatorLambdaOriginStarterStepFunctionOriginStarterHelperA28A5905",
+            "SimulatorManagerOriginSimulatorLambdaOriginEraserStepFunctionOriginEraserHelperFE478FE3",
+            "SimulatorManagerOriginSimulatorLambdaOriginEventHandler70EF4889",
+            "SimulatorManagerDestinationSimulatorLambdaDestinationGeneratorStepFunctionDestinationGeneratorHelperD80AFFC5",
+            "SimulatorManagerDestinationSimulatorLambdaDestinationStarterStepFunctionDestinationStarterHelper6D16BE0E",
+            "SimulatorManagerDestinationSimulatorLambdaDestinationEraserStepFunctionDestinationEraserHelperEEF2F7D1",
+            "SimulatorManagerDestinationSimulatorLambdaE614D361",
+            "SimulatorManagerDestinationSimulatorLambdaS3PresignedUrlLambdaE6ECBCFE",
+            "SimulatorManagerOrderSimulatorLambda1D914205",
+            "SimulatorManagerInstantDeliveryDispatcherAssignmentQueryLambda7796E184",
+            "SimulatorManagerSameDayDeliveryDispatcherAssignmentQueryLambda00538C73"
           ],
           "line_numbers": [
-            390,
-            651
+            90,
+            6108,
+            6414,
+            6556,
+            6746,
+            6935,
+            7286,
+            7613,
+            8407,
+            8661,
+            9011,
+            9341,
+            9687,
+            10040,
+            10181,
+            10726,
+            10896
           ],
           "element_types": [
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
             "resource",
             "resource"
           ]
@@ -2148,71 +2545,102 @@
           "type": "WARN",
           "message": "Lambda functions should define ReservedConcurrentExecutions to reserve simultaneous executions",
           "logical_resource_ids": [
-            "DeploymentHandlerLambda04B758EE",
-            "AWS679f53fac002430cb0da5b7982bd22872D164C4C"
+            "AWS679f53fac002430cb0da5b7982bd22872D164C4C",
+            "SimulatorManagerSimulatorManagerLambdaESCSStepFunctionInvokerECSTaskRunHelperF98A49C7",
+            "SimulatorManagerSimulatorManagerLambda269D5609",
+            "SimulatorManagerEventsSimulatorEventSimulatorLambda192B31F9",
+            "SimulatorManagerPolygonManagerLambdaB5FAE450",
+            "SimulatorManagerOriginSimulatorLambdaOriginGeneratorStepFunctionOriginGeneratorHelperC2BD95BD",
+            "SimulatorManagerOriginSimulatorLambdaOriginStarterStepFunctionOriginStarterHelperA28A5905",
+            "SimulatorManagerOriginSimulatorLambdaOriginEraserStepFunctionOriginEraserHelperFE478FE3",
+            "SimulatorManagerOriginSimulatorLambda669B2FA5",
+            "SimulatorManagerOriginSimulatorLambdaOriginStatusUpdateLambdaD5130653",
+            "SimulatorManagerOriginSimulatorLambdaOriginEventHandler70EF4889",
+            "SimulatorManagerDestinationSimulatorLambdaDestinationGeneratorStepFunctionDestinationGeneratorHelperD80AFFC5",
+            "SimulatorManagerDestinationSimulatorLambdaDestinationStarterStepFunctionDestinationStarterHelper6D16BE0E",
+            "SimulatorManagerDestinationSimulatorLambdaDestinationEraserStepFunctionDestinationEraserHelperEEF2F7D1",
+            "SimulatorManagerDestinationSimulatorLambdaE614D361",
+            "SimulatorManagerDestinationSimulatorLambdaDestinationStatusUpdateLambda7FD0C441",
+            "SimulatorManagerDestinationSimulatorLambdaS3PresignedUrlLambdaE6ECBCFE",
+            "SimulatorManagerOrderSimulatorLambda1D914205",
+            "SimulatorManagerStatsSimulatorLambdaStatisticsLambdaD6482994",
+            "SimulatorManagerInstantDeliveryDispatcherAssignmentQueryLambda7796E184",
+            "SimulatorManagerSameDayDeliveryDispatcherAssignmentQueryLambda00538C73"
           ],
           "line_numbers": [
-            390,
-            651
+            90,
+            6108,
+            6414,
+            6556,
+            6746,
+            6935,
+            7286,
+            7613,
+            8000,
+            8208,
+            8407,
+            8661,
+            9011,
+            9341,
+            9687,
+            9858,
+            10040,
+            10181,
+            10498,
+            10726,
+            10896
           ],
           "element_types": [
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
+            "resource",
             "resource",
             "resource"
           ]
         },
         {
-          "id": "W35",
-          "name": "S3BucketAccessLoggingRule",
+          "id": "W84",
+          "name": "LogsLogGroupEncryptedRule",
           "type": "WARN",
-          "message": "S3 Bucket should have access logging configured",
+          "message": "CloudWatchLogs LogGroup should specify a KMS Key Id to encrypt the log data",
           "logical_resource_ids": [
-            "ConfigStorageConfigBucketA9569935"
+            "MemDBMonitoringMemDBMonitoringTaskDefMemDBMonitoringContainerLogGroupE54AFECA"
           ],
           "line_numbers": [
-            131
-          ],
-          "element_types": [
-            "resource"
-          ]
-        }
-      ]
-    }
-  },
-  {
-    "filename": "./cdk.out.dev/DevPersistentBackendIdentityStackPersistentF9E4E218.nested.template.json",
-    "file_results": {
-      "failure_count": 0,
-      "violations": [
-        {
-          "id": "W57",
-          "name": "CognitoIdentityPoolAllowUnauthenticatedIdentitiesRule",
-          "type": "WARN",
-          "message": "AWS::Cognito::IdentityPool AllowUnauthenticatedIdentities property should be false but CAN be true if proper restrictive IAM roles and permissions are established for unauthenticated users.",
-          "logical_resource_ids": [
-            "hyperprotoIdentityPool"
-          ],
-          "line_numbers": [
-            266
+            11370
           ],
           "element_types": [
             "resource"
           ]
         },
         {
-          "id": "W11",
-          "name": "IamRoleWildcardResourceOnPermissionsPolicyRule",
+          "id": "W86",
+          "name": "LogsLogGroupRetentionRule",
           "type": "WARN",
-          "message": "IAM role should not allow * resource on its permissions policy",
+          "message": "CloudWatchLogs LogGroup should specify RetentionInDays to expire the log data",
           "logical_resource_ids": [
-            "hyperprotoUserPoolsmsRole614F432B",
-            "AuthenticatedRole86104F1A"
+            "MemDBMonitoringMemDBMonitoringTaskDefMemDBMonitoringContainerLogGroupE54AFECA"
           ],
           "line_numbers": [
-            4,
-            311
+            11370
           ],
           "element_types": [
-            "resource",
             "resource"
           ]
         },
@@ -2222,99 +2650,43 @@
           "type": "WARN",
           "message": "Resource found with an explicit name, this disallows updates that require replacement of this resource",
           "logical_resource_ids": [
-            "AuthenticatedRole86104F1A",
-            "hyperprotoUnauthenticatedRole73422B8B"
+            "MemDBMonitoringMemDBMonitoringALB9CBAD81B",
+            "MemDBMonitoringMemDBMonitoringTaskRoleAEA5DFE5"
           ],
           "line_numbers": [
-            311,
-            380
+            11553,
+            11231
           ],
           "element_types": [
-            "resource",
-            "resource"
-          ]
-        }
-      ]
-    }
-  },
-  {
-    "filename": "./cdk.out.dev/DevBackendOrderOrchestrationStack113F9242.nested.template.json",
-    "file_results": {
-      "failure_count": 0,
-      "violations": [
-        {
-          "id": "W12",
-          "name": "IamPolicyWildcardResourceRule",
-          "type": "WARN",
-          "message": "IAM policy should not allow * resource",
-          "logical_resource_ids": [
-            "OrderManagerStackOrderManagerHelperServiceRoleDefaultPolicy272FF686",
-            "OrderManagerStackProviderRuleEngineServiceRoleDefaultPolicy3804ECF8",
-            "OrderManagerStackOrderManagerHandlerServiceRoleDefaultPolicy8E9977C4"
-          ],
-          "line_numbers": [
-            56,
-            246,
-            695
-          ],
-          "element_types": [
-            "resource",
             "resource",
             "resource"
           ]
         },
         {
-          "id": "W58",
-          "name": "LambdaFunctionCloudWatchLogsRule",
+          "id": "W76",
+          "name": "SPCMRule",
           "type": "WARN",
-          "message": "Lambda functions require permission to write CloudWatch Logs",
+          "message": "SPCM for IAM policy document is higher than 25",
           "logical_resource_ids": [
-            "OrderManagerStackOrderManagerHelperA1E5F379",
-            "OrderManagerStackProviderRuleEngineACDAE3AD",
-            "OrderManagerStackOrderManagerHandler71247775"
+            "SimulatorManagerOriginSimulatorLambdaOriginGeneratorStepFunctionOriginGeneratorHelperServiceRoleDefaultPolicy7F7C5518",
+            "SimulatorManagerOriginSimulatorLambdaOriginStarterStepFunctionOriginStarterHelperServiceRoleDefaultPolicyCBE0EF66",
+            "SimulatorManagerOriginSimulatorLambdaServiceRoleDefaultPolicyB9182468",
+            "SimulatorManagerDestinationSimulatorLambdaDestinationGeneratorStepFunctionDestinationGeneratorHelperServiceRoleDefaultPolicy26A5D211",
+            "SimulatorManagerDestinationSimulatorLambdaDestinationStarterStepFunctionDestinationStarterHelperServiceRoleDefaultPolicy4FA4D8AD",
+            "SimulatorManagerDestinationSimulatorLambdaServiceRoleDefaultPolicyEC8238D5"
           ],
           "line_numbers": [
-            120,
-            342,
-            767
+            6833,
+            7198,
+            7865,
+            8559,
+            8923,
+            9581
           ],
           "element_types": [
             "resource",
             "resource",
-            "resource"
-          ]
-        },
-        {
-          "id": "W89",
-          "name": "LambdaFunctionInsideVPCRule",
-          "type": "WARN",
-          "message": "Lambda functions should be deployed inside a VPC",
-          "logical_resource_ids": [
-            "OrderManagerStackProviderRuleEngineACDAE3AD"
-          ],
-          "line_numbers": [
-            342
-          ],
-          "element_types": [
-            "resource"
-          ]
-        },
-        {
-          "id": "W92",
-          "name": "LambdaFunctionReservedConcurrentExecutionsRule",
-          "type": "WARN",
-          "message": "Lambda functions should define ReservedConcurrentExecutions to reserve simultaneous executions",
-          "logical_resource_ids": [
-            "OrderManagerStackOrderManagerHelperA1E5F379",
-            "OrderManagerStackProviderRuleEngineACDAE3AD",
-            "OrderManagerStackOrderManagerHandler71247775"
-          ],
-          "line_numbers": [
-            120,
-            342,
-            767
-          ],
-          "element_types": [
+            "resource",
             "resource",
             "resource",
             "resource"
@@ -2337,7 +2709,7 @@
             "SimulatorWebsiteHostingCloudFrontDistroCFDistributionF9EFFC1F"
           ],
           "line_numbers": [
-            2013
+            1889
           ],
           "element_types": [
             "resource"
@@ -2352,7 +2724,7 @@
             "SimulatorWebsiteHostingCloudFrontDistroCFDistributionF9EFFC1F"
           ],
           "line_numbers": [
-            2013
+            1889
           ],
           "element_types": [
             "resource"
@@ -2388,9 +2760,7 @@
             "SimulatorECSStackDestinationSimulatorContainerSimulatorRoledestinationDefaultPolicyF258DA5E",
             "SimulatorECSStackDestinationSimulatorContainerECSExecutionRoledestinationDefaultPolicy0070E31D",
             "SimulatorECSStackOriginSimulatorContainerSimulatorRoleoriginDefaultPolicy5C9476E8",
-            "SimulatorECSStackOriginSimulatorContainerECSExecutionRoleoriginDefaultPolicy6A16E111",
-            "SimulatorWebsiteHostingWebACLWebACLCreateCustomResourcePolicy068617E0",
-            "SimulatorWebsiteHostingWebACLWebACLDeleteCustomResourcePolicyC41DCB8E"
+            "SimulatorECSStackOriginSimulatorContainerECSExecutionRoleoriginDefaultPolicy6A16E111"
           ],
           "line_numbers": [
             442,
@@ -2399,13 +2769,9 @@
             864,
             1015,
             1299,
-            1450,
-            1889,
-            1934
+            1450
           ],
           "element_types": [
-            "resource",
-            "resource",
             "resource",
             "resource",
             "resource",
@@ -2650,132 +3016,42 @@
     }
   },
   {
-    "filename": "./cdk.out.dev/DevBackendMicroServiceNestedStackC61F3420.nested.template.json",
+    "filename": "./cdk.out.dev/SimulatorBackendSimulatorWebsiteHosting8EDC668F.nested.template.json",
     "file_results": {
       "failure_count": 0,
       "violations": [
-        {
-          "id": "W59",
-          "name": "ApiGatewayMethodAuthorizationTypeRule",
-          "type": "WARN",
-          "message": "AWS::ApiGateway::Method should not have AuthorizationType set to 'NONE' unless it is of HttpMethod: OPTIONS.",
-          "logical_resource_ids": [
-            "GeoTrackingRestApiapigeotrackinginternaldriverlocationiddriverIdGET43641EFB",
-            "GeoTrackingRestApiapigeotrackinginternaldriverlocationqueryGET6ADEEDBC",
-            "GeoTrackingRestApiapigeotrackinginternaldriverlocationqueryPOST47790ED0",
-            "GeoTrackingRestApiapigeotrackinginternaldriverlocationpolygonpolygonIdGET6333EC74",
-            "GeoTrackingRestApiapigeotrackinginternaldriverlocationpolygonPOSTE86934E0",
-            "GeoTrackingRestApiapigeotrackinginternaldemareasettingsGET2ABAA416"
-          ],
-          "line_numbers": [
-            1429,
-            1594,
-            1713,
-            1935,
-            2043,
-            2208
-          ],
-          "element_types": [
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource"
-          ]
-        },
-        {
-          "id": "W69",
-          "name": "ApiGatewayStageAccessLoggingRule",
-          "type": "WARN",
-          "message": "AWS::ApiGateway::Stage should have the AccessLogSetting property defined.",
-          "logical_resource_ids": [
-            "GeoTrackingRestApiDeploymentStageprod14BF27C1"
-          ],
-          "line_numbers": [
-            154
-          ],
-          "element_types": [
-            "resource"
-          ]
-        },
-        {
-          "id": "W12",
-          "name": "IamPolicyWildcardResourceRule",
-          "type": "WARN",
-          "message": "IAM policy should not allow * resource",
-          "logical_resource_ids": [
-            "GeoTrackingRestApiGetDriverLocationLambdaServiceRoleDefaultPolicy0E4F7265",
-            "GeoTrackingRestApiQueryDriversLambdaServiceRoleDefaultPolicy717BCDFA",
-            "GeoTrackingRestApiListDriversForPolygonLambdaServiceRoleDefaultPolicyBF20FE88",
-            "GeoTrackingRestApiGeofencingServiceServiceRoleDefaultPolicyD1510CE6",
-            "LambdaFunctionsStackDriverLocationCleanupLambdaServiceRoleDefaultPolicyB15EEDED",
-            "LambdaFunctionsStackDriverLocationUpdateIngestLambdaServiceRoleDefaultPolicy9CA99350",
-            "LambdaFunctionsStackDriverGeofencingLambdaServiceRoleDefaultPolicyC0DC3C47",
-            "LambdaFunctionsStackDriverStatusUpdateLambdaServiceRoleDefaultPolicy2EAF1E1C",
-            "ApiGeoTrackingGetDemAreaSettingsLambdaServiceRoleDefaultPolicy4C5CDB75"
-          ],
-          "line_numbers": [
-            2701,
-            2882,
-            3063,
-            3297,
-            3729,
-            3992,
-            4303,
-            4606,
-            5017
-          ],
-          "element_types": [
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource"
-          ]
-        },
         {
           "id": "W58",
           "name": "LambdaFunctionCloudWatchLogsRule",
           "type": "WARN",
           "message": "Lambda functions require permission to write CloudWatch Logs",
           "logical_resource_ids": [
-            "GeoTrackingRestApiGetDriverLocationLambda16797A58",
-            "GeoTrackingRestApiQueryDriversLambdaDC17E2A5",
-            "GeoTrackingRestApiListDriversForPolygonLambda2F311273",
-            "GeoTrackingRestApiGeofencingServiceC5DE9446",
-            "LambdaFunctionsStackDriverLocationCleanupLambda1F1F880E",
-            "LambdaFunctionsStackDriverLocationUpdateIngestLambda504D6AD3",
-            "LambdaFunctionsStackDriverGeofencingLambda40A7BA6E",
-            "LambdaFunctionsStackDriverStatusUpdateLambda84DE0655",
-            "LambdaFunctionsStackESInitialSetupLambdaB25C3E0D",
-            "ApiGeoTrackingGetDemAreaSettingsLambda6C4A12E4"
+            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536",
+            "AWS679f53fac002430cb0da5b7982bd22872D164C4C"
           ],
           "line_numbers": [
-            2748,
-            2929,
-            3157,
-            3354,
-            3809,
-            4104,
-            4407,
-            4681,
-            4859,
-            5063
+            191,
+            457
           ],
           "element_types": [
             "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
+            "resource"
+          ]
+        },
+        {
+          "id": "W89",
+          "name": "LambdaFunctionInsideVPCRule",
+          "type": "WARN",
+          "message": "Lambda functions should be deployed inside a VPC",
+          "logical_resource_ids": [
+            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536",
+            "AWS679f53fac002430cb0da5b7982bd22872D164C4C"
+          ],
+          "line_numbers": [
+            191,
+            457
+          ],
+          "element_types": [
             "resource",
             "resource"
           ]
@@ -2786,69 +3062,12 @@
           "type": "WARN",
           "message": "Lambda functions should define ReservedConcurrentExecutions to reserve simultaneous executions",
           "logical_resource_ids": [
-            "GeoTrackingRestApiGetDriverLocationLambda16797A58",
-            "GeoTrackingRestApiQueryDriversLambdaDC17E2A5",
-            "GeoTrackingRestApiListDriversForPolygonLambda2F311273",
-            "GeoTrackingRestApiGeofencingServiceC5DE9446",
-            "LambdaFunctionsStackDriverLocationCleanupLambda1F1F880E",
-            "LambdaFunctionsStackDriverLocationUpdateIngestLambda504D6AD3",
-            "LambdaFunctionsStackDriverGeofencingLambda40A7BA6E",
-            "LambdaFunctionsStackDriverStatusUpdateLambda84DE0655",
-            "LambdaFunctionsStackESInitialSetupLambdaB25C3E0D",
-            "ApiGeoTrackingGetDemAreaSettingsLambda6C4A12E4"
+            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536",
+            "AWS679f53fac002430cb0da5b7982bd22872D164C4C"
           ],
           "line_numbers": [
-            2748,
-            2929,
-            3157,
-            3354,
-            3809,
-            4104,
-            4407,
-            4681,
-            4859,
-            5063
-          ],
-          "element_types": [
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource",
-            "resource"
-          ]
-        },
-        {
-          "id": "W28",
-          "name": "ResourceWithExplicitNameRule",
-          "type": "WARN",
-          "message": "Resource found with an explicit name, this disallows updates that require replacement of this resource",
-          "logical_resource_ids": [
-            "GeoTrackingRestApihyperprotoApiKeyGeoTrackingApiZ14orxO22A52444"
-          ],
-          "line_numbers": [
-            2582
-          ],
-          "element_types": [
-            "resource"
-          ]
-        },
-        {
-          "id": "W48",
-          "name": "SqsQueueKmsMasterKeyIdRule",
-          "type": "WARN",
-          "message": "SQS Queue should specify KmsMasterKeyId property",
-          "logical_resource_ids": [
-            "LambdaFunctionsStackKinesisIngestConsumerdriverIngestDlqB65AFC33",
-            "LambdaFunctionsStackKinesisGeofencingConsumergeofencingDlq731D69E3"
-          ],
-          "line_numbers": [
-            4190,
-            4493
+            191,
+            457
           ],
           "element_types": [
             "resource",


### PR DESCRIPTION
*Issue #, if available:* closes #18

*Description of changes:*

* external mock provider manual deployment and config update not needed anymore, all automated; deployed API urls stored as SSM param
* external mock provider supports variable number of providers to deploy (only depends on config)
* `externalProviderConfig` configuration structure changed
* `quickstart` doc updated

`ProviderStack` , `OrderManager` and `CustomResourcesStack` still need to be generalized to support variable number of external providers set in config (`prio:low` for now)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
