### PR TITLE
feat(infra): add require IMDSv2 for asg created instances

### DIFF
--- a/packages/@prototype/monitoring/src/Monitoring/index.ts
+++ b/packages/@prototype/monitoring/src/Monitoring/index.ts
@@ -89,6 +89,7 @@ export class Monitoring extends Construct {
 			vpc,
 			vpcSubnets: vpc.selectSubnets({ subnetType: ec2.SubnetType.PUBLIC }),
 			role: debugInstanceRole,
+			requireImdsv2: true,
 		})
 
 		debugInstance.userData.addCommands(

--- a/prototype/infra/bin/dev-infra.ts
+++ b/prototype/infra/bin/dev-infra.ts
@@ -16,7 +16,7 @@
  *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                                       *
  *********************************************************************************************************************/
 import 'source-map-support/register'
-import { App, Tags } from 'aws-cdk-lib'
+import { App, Aspects, Tags, aws_autoscaling as autoscaling } from 'aws-cdk-lib'
 import config from '../config'
 import { BackendStack } from '../lib/stack/root/BackendStack'
 import { PersistentBackendStack } from '../lib/stack/root/PersistentBackendStack'
@@ -99,4 +99,9 @@ const simulatorMainStack = new SimulatorMainStack(app, 'Simulator-Backend', {
 	namespace: simulatorNamespace,
 })
 
+// make sure that IMDSv2 is required on instances deployed by AutoScalingGroups
+const asgImdsv2Required = new autoscaling.AutoScalingGroupRequireImdsv2Aspect()
+Aspects.of(app).add(asgImdsv2Required)
+
+// tag all deployed resources
 Tags.of(app).add('proto:deployment:id', `${config.namespace}-lastmiledelivery-deployment`)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Enforce v2 IMDS when EC2 instances are spun up. More info in [EC2 documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
