### PR TITLE
fix(dispatcher): pass createdAt to dispatcher

### DIFF
--- a/prototype/dispatch/delivery-dispatch/apps/app-core/src/main/java/dev/aws/proto/apps/appcore/api/DispatchService.java
+++ b/prototype/dispatch/delivery-dispatch/apps/app-core/src/main/java/dev/aws/proto/apps/appcore/api/DispatchService.java
@@ -82,7 +82,7 @@ public abstract class DispatchService<
      * @param problemId The generated ID for the problem.
      * @param request   The request object that holds all the necessary information to build the planning variables/entities.
      */
-    protected abstract void solveDispatchProblem(UUID problemId, TDispatchRequest request);
+    protected abstract void solveDispatchProblem(UUID problemId, long createdAt, TDispatchRequest request);
 
     /**
      * Placeholder to create custom implementations for storing solution data, cleaning up, etc.

--- a/prototype/dispatch/delivery-dispatch/apps/instant-sequential/src/main/java/dev/aws/proto/apps/instant/sequential/api/DispatchResource.java
+++ b/prototype/dispatch/delivery-dispatch/apps/instant-sequential/src/main/java/dev/aws/proto/apps/instant/sequential/api/DispatchResource.java
@@ -27,6 +27,8 @@ import org.slf4j.LoggerFactory;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import java.util.UUID;
@@ -60,8 +62,9 @@ public class DispatchResource {
         logger.info("Assign drivers request :: centroid :: {}/{} :: orders = {}", req.getCentroid().getLatitude(), req.getCentroid().getLongitude(), req.getOrders().length);
 
         UUID problemId = UUID.randomUUID();
-        jobScheduler.<DispatchService>enqueue(dispatcherService -> dispatcherService.solveDispatchProblem(problemId, req));
-        dispatcherService.saveInitialEnqueued(problemId, req);
+        long createdAt = Timestamp.valueOf(LocalDateTime.now()).getTime();
+        jobScheduler.<DispatchService>enqueue(dispatcherService -> dispatcherService.solveDispatchProblem(problemId, createdAt, req));
+        dispatcherService.saveInitialEnqueued(problemId, createdAt, req);
         return RequestResult.of(problemId.toString());
     }
 
@@ -111,4 +114,3 @@ public class DispatchResource {
 
 
 }
-

--- a/prototype/dispatch/delivery-dispatch/apps/instant-sequential/src/main/java/dev/aws/proto/apps/instant/sequential/api/DispatchService.java
+++ b/prototype/dispatch/delivery-dispatch/apps/instant-sequential/src/main/java/dev/aws/proto/apps/instant/sequential/api/DispatchService.java
@@ -48,8 +48,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-import java.sql.Timestamp;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -84,8 +82,7 @@ public class DispatchService extends dev.aws.proto.apps.appcore.api.DispatchServ
     }
 
     @Override
-    public void solveDispatchProblem(UUID problemId, DispatchRequest req) {
-        long createdAt = Timestamp.valueOf(LocalDateTime.now()).getTime();
+    public void solveDispatchProblem(UUID problemId, long createdAt, DispatchRequest req) {
         String executionId = req.getExecutionId();
 
         logger.trace("SolveDispatchProblem request :: problemId={} :: executionId={}", problemId, executionId);
@@ -242,11 +239,11 @@ public class DispatchService extends dev.aws.proto.apps.appcore.api.DispatchServ
         }
     }
 
-    public void saveInitialEnqueued(UUID problemId, DispatchRequest req) {
+    public void saveInitialEnqueued(UUID problemId, long createdAt, DispatchRequest req) {
         assignmentService.saveAssignment(DispatchResult.builder()
                 .problemId(problemId)
                 .executionId(req.getExecutionId())
-                .createdAt(Timestamp.valueOf(LocalDateTime.now()).getTime())
+                .createdAt(createdAt)
                 .assigned(new ArrayList<>())
                 .unassigned(new ArrayList<>())
                 .state("ENQUEUED")

--- a/prototype/dispatch/delivery-dispatch/apps/sameday-directpudo/src/main/java/dev/aws/proto/apps/sameday/directpudo/api/DispatchResource.java
+++ b/prototype/dispatch/delivery-dispatch/apps/sameday-directpudo/src/main/java/dev/aws/proto/apps/sameday/directpudo/api/DispatchResource.java
@@ -26,6 +26,8 @@ import org.slf4j.LoggerFactory;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import java.util.UUID;
@@ -49,14 +51,15 @@ public class DispatchResource {
         logger.info("Dispatch solve request :: orders = {}", req.getOrders().length);
 
         UUID problemId = UUID.randomUUID();
+        long createdAt = Timestamp.valueOf(LocalDateTime.now()).getTime();
 
         try {
-            dispatchService.saveInitialEnqueued(problemId, req);
+            dispatchService.saveInitialEnqueued(problemId, createdAt, req);
         } catch (Exception e) {
             logger.error("There was an error saving the initial enqueued job into the database: {}", e.getMessage());
         }
 
-        jobScheduler.<DispatchService>enqueue(dispatchService -> dispatchService.solveDispatchProblem(problemId, req));
+        jobScheduler.<DispatchService>enqueue(dispatchService -> dispatchService.solveDispatchProblem(problemId, createdAt, req));
         return RequestResult.of(problemId.toString());
     }
 

--- a/prototype/dispatch/delivery-dispatch/apps/sameday-directpudo/src/main/java/dev/aws/proto/apps/sameday/directpudo/api/DispatchService.java
+++ b/prototype/dispatch/delivery-dispatch/apps/sameday-directpudo/src/main/java/dev/aws/proto/apps/sameday/directpudo/api/DispatchService.java
@@ -113,8 +113,7 @@ public class DispatchService extends dev.aws.proto.apps.appcore.api.DispatchServ
      * @param req       The dispatch request object.
      */
     @Override
-    public void solveDispatchProblem(UUID problemId, DispatchRequest req) {
-        long createdAt = Timestamp.valueOf(LocalDateTime.now()).getTime();
+    public void solveDispatchProblem(UUID problemId, long createdAt, DispatchRequest req) {
         String executionId = req.getExecutionId();
         logger.info("SolveDispatchProblem request :: problemId={} :: executionId={}", problemId, executionId);
 
@@ -344,11 +343,11 @@ public class DispatchService extends dev.aws.proto.apps.appcore.api.DispatchServ
         return result;
     }
 
-    public void saveInitialEnqueued(UUID problemId, DispatchRequest req) {
+    public void saveInitialEnqueued(UUID problemId, long createdAt, DispatchRequest req) {
         solverJobService.save(SolverJob.builder()
                 .problemId(problemId)
                 .executionId(req.getExecutionId())
-                .createdAt(Timestamp.valueOf(LocalDateTime.now()).getTime())
+                .createdAt(createdAt)
                 .state("ENQUEUED")
                 .score("NA")
                 .build());


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Create `createdAt` at `DispatchResoruce`'s `assign-drivers` handler and pass it to dispatcher to avoid creating duplicated assignment entries.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
